### PR TITLE
fix: add uvicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pydantic
 fastapi
 numpy # assuming lastest version unless we run into bugs
 scipy # assuming lastest version unless we run into bugs
-httpx
+httpxuvicorn


### PR DESCRIPTION
Fixes #6

uvicorn is required to run the FastAPI application but was missing from requirements.txt.

This PR adds `uvicorn` to the requirements list so users can properly start the server after installation.