### PR TITLE
Fixes the agent harness, and the face orientation

### DIFF
--- a/opencad/runtime.py
+++ b/opencad/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from opencad_kernel.operations.handlers import OpenCadKernel
 from opencad_kernel.operations.registry import OperationRegistry
@@ -9,11 +9,14 @@ from opencad.kernel_adapter import execute_feature_node, registry_result_to_dict
 from opencad_tree.models import FeatureNode, FeatureTree
 from opencad_tree.service import FeatureTreeService
 
+KernelCallFn = Callable[[str, dict[str, Any]], dict[str, Any]]
+
 
 class RuntimeContext:
     """Single-process OpenCAD runtime for headless/fluent usage."""
 
-    def __init__(self, *, id_strategy: str = "readable") -> None:
+    def __init__(self, *, id_strategy: str = "readable", kernel_call_fn: KernelCallFn | None = None) -> None:
+        self._external_kernel_call = kernel_call_fn
         self.kernel = OpenCadKernel(id_strategy=id_strategy)
         self.registry = OperationRegistry(self.kernel)
         self.tree = FeatureTree(root_id="root")
@@ -70,8 +73,12 @@ class RuntimeContext:
         feature_id: str | None = None,
     ) -> tuple[str, str]:
         """Execute a kernel operation and append a built feature node."""
+        print("calling operation: ", operation)
         depends = depends_on or []
-        response = registry_result_to_dict(self.registry, operation, payload)
+        if self._external_kernel_call is not None:
+            response = self._external_kernel_call(operation, payload)
+        else:
+            response = registry_result_to_dict(self.registry, operation, payload)
         if not response.get("ok"):
             raise RuntimeError(f"Operation '{operation}' failed: {response.get('message', 'unknown error')}")
         shape_id = response.get("shape_id")

--- a/opencad_agent/api.py
+++ b/opencad_agent/api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
+
+load_dotenv()
 
 from opencad.api_app import create_api_app
 from opencad_agent.models import ChatRequest, ChatResponse

--- a/opencad_agent/llm.py
+++ b/opencad_agent/llm.py
@@ -23,6 +23,17 @@ def _resolve_model_name(provider: str | None, model: str) -> str:
     return model
 
 
+def _strip_code_fences(code: str) -> str:
+    code = code.strip()
+    if code.startswith("```python"):
+        code = code[len("```python"):]
+    elif code.startswith("```"):
+        code = code[len("```"):]
+    if code.endswith("```"):
+        code = code[:-len("```")]
+    return code.strip()
+
+
 def _extract_message_content(response: Any) -> str:
     choices = response.get("choices") if isinstance(response, dict) else getattr(response, "choices", None)
     if not choices:
@@ -69,4 +80,5 @@ class LiteLlmProvider:
             messages=messages,
             temperature=HIGH_REASONING_CODE_TEMPERATURE if reasoning else DEFAULT_CODE_TEMPERATURE,
         )
-        return _extract_message_content(response).strip()
+        print("About to execute: ", response)
+        return _strip_code_fences(_extract_message_content(response))

--- a/opencad_agent/prompting.py
+++ b/opencad_agent/prompting.py
@@ -53,6 +53,30 @@ def _load_example_scripts() -> str:
     return "\n\n".join(snippets)
 
 
+_API_REFERENCE = """\
+Sketch methods (all return self for chaining):
+  Sketch(name=str, plane=str, origin=tuple)
+  .line(start=(x,y), end=(x,y))
+  .rect(width, height, *, origin=(x,y))
+  .circle(radius, *, center=(x,y), subtract=bool)   # subtract cuts a hole in the profile
+
+Part methods (all return self for chaining):
+  Part(name=str)
+  .box(length, width, height, *, name=str)
+  .cylinder(radius, height, *, name=str)
+  .sphere(radius, *, name=str)
+  .extrude(sketch, *, depth, both=False, name=str)   # sketch is a Sketch instance, NO subtract arg
+  .union(other_part, *, name=str)
+  .cut(other_part, *, name=str)
+  .fillet(*, edges=None|"all"|"top"|[id,...], radius, name=str)
+  .chamfer(*, edges=None|"all"|"top"|[id,...], distance, name=str)
+  .offset(distance, *, name=str)
+  .linear_pattern(*, direction=(x,y,z), count, spacing, name=str)
+  .circular_pattern(*, axis_origin=(x,y,z), axis_direction=(x,y,z), count, angle=360.0, name=str)
+  .mirror(*, plane_origin=(x,y,z), plane_normal=(x,y,z), name=str)
+"""
+
+
 def build_code_generation_prompt(tree_state: FeatureTree) -> str:
     base_prompt = build_system_prompt(tree_state)
     examples = _load_example_scripts()
@@ -65,7 +89,10 @@ def build_code_generation_prompt(tree_state: FeatureTree) -> str:
         "- Prefer a named sketch variable followed by a named Part fluent chain.\n"
         "- Use descriptive names for sketches, parts, and operations.\n"
         "- Keep the script self-contained and aligned with the examples below.\n"
+        "- Do not enclose the returned code with comment markers, or markers saying it's python, assume that the code is executed.\n"
         "\n"
+        "API reference (use ONLY these signatures — do not invent parameters):\n"
+        f"{_API_REFERENCE}\n"
         "Reference examples:\n"
         f"{examples}\n"
     )

--- a/opencad_agent/service.py
+++ b/opencad_agent/service.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import os
+from copy import deepcopy
+
 from opencad_agent.llm import LiteLlmProvider
-from opencad_agent.models import ChatRequest, ChatResponse
+from opencad_agent.models import ChatRequest, ChatResponse, OperationExecution
 from opencad_agent.planner import OpenCadPlanner
 from opencad_agent.prompting import build_code_generation_prompt, build_system_prompt
-from opencad_agent.tools import KernelCall, ToolRuntime
+from opencad_agent.tools import KernelCall, ToolRuntime, _call_kernel
+from opencad_tree.models import FeatureTree
 
 
 class OpenCadAgentService:
@@ -31,11 +35,12 @@ class OpenCadAgentService:
 
         if request.generate_code:
             generated_code = self._generate_code(request)
+            new_tree, operations = self._run_generated_code(generated_code, request.tree_state)
             return ChatResponse(
                 response=generated_code,
                 generated_code=generated_code,
-                operations_executed=[],
-                new_tree_state=runtime.get_tree_state(),
+                operations_executed=operations,
+                new_tree_state=new_tree,
             )
 
         response_text, operations = self.planner.execute(
@@ -50,12 +55,71 @@ class OpenCadAgentService:
             new_tree_state=runtime.get_tree_state(),
         )
 
+    def _run_generated_code(
+        self, code: str, tree_state: FeatureTree
+    ) -> tuple[FeatureTree, list[OperationExecution]]:
+        """Execute generated Part/Sketch code against the kernel and return the updated tree."""
+        from opencad.runtime import RuntimeContext, set_default_context, reset_default_context
+        print("About to run code: ", code)
+
+        _use_live = (
+            self.live_kernel
+            if self.live_kernel is not None
+            else (os.environ.get("OPENCAD_AGENT_LIVE_KERNEL", "false").lower() == "true" or self.kernel_call is not None)
+        )
+        kernel_call_fn = (self.kernel_call or _call_kernel) if _use_live else None
+
+        ctx = RuntimeContext(kernel_call_fn=kernel_call_fn)
+        ctx.tree = deepcopy(tree_state)
+        ctx._sync_counters()
+        prior_nodes = set(ctx.tree.nodes.keys())
+
+        set_default_context(ctx)
+        try:
+            exec(code, {"__name__": "__main__"})  # noqa: S102
+        except Exception as exc:
+            import httpx
+            if kernel_call_fn is not None and isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError, httpx.TimeoutException)):
+                # Kernel unreachable — fall back to in-process and re-run
+                reset_default_context()
+                ctx = RuntimeContext()
+                ctx.tree = deepcopy(tree_state)
+                ctx._sync_counters()
+                prior_nodes = set(ctx.tree.nodes.keys())
+                set_default_context(ctx)
+                try:
+                    exec(code, {"__name__": "__main__"})  # noqa: S102
+                except Exception as exc2:
+                    raise RuntimeError(f"Generated code execution failed: {exc2}") from exc2
+                finally:
+                    reset_default_context()
+            else:
+                raise RuntimeError(f"Generated code execution failed: {exc}") from exc
+        else:
+            reset_default_context()
+
+        operations: list[OperationExecution] = []
+        for node_id, node in ctx.tree.nodes.items():
+            if node_id not in prior_nodes:
+                operations.append(
+                    OperationExecution(
+                        tool=node.operation,
+                        status="ok",
+                        arguments=node.parameters,
+                        result={"shape_id": node.shape_id or ""},
+                    )
+                )
+
+        return ctx.tree, operations
+
+
     def _generate_code(self, request: ChatRequest) -> str:
-        use_llm = request.llm_model is not None
-        if use_llm:
+        provider = request.llm_provider or os.environ.get("OPENCAD_LLM_PROVIDER")
+        model = request.llm_model or os.environ.get("OPENCAD_LLM_MODEL")
+        if model:
             return self.llm_client.generate_code(
-                provider=request.llm_provider,
-                model=request.llm_model,
+                provider=provider,
+                model=model,
                 system_prompt=build_code_generation_prompt(request.tree_state),
                 user_message=request.message,
                 conversation_history=request.conversation_history,

--- a/opencad_agent/tests/test_agent.py
+++ b/opencad_agent/tests/test_agent.py
@@ -145,10 +145,11 @@ def test_chat_api_can_return_generated_code() -> None:
     assert response.status_code == 200
 
     body = response.json()
-    assert body["operations_executed"] == []
+    assert len(body["operations_executed"]) >= 1
     assert body["generated_code"].startswith('"""Generated OpenCAD example')
     assert "from opencad import Part, Sketch" in body["generated_code"]
     assert body["new_tree_state"]["root_id"] == "root"
+    assert len(body["new_tree_state"]["nodes"]) > 1
 
 
 def test_healthz() -> None:

--- a/opencad_agent/tools.py
+++ b/opencad_agent/tools.py
@@ -19,6 +19,7 @@ KernelCall = Callable[[str, dict[str, Any]], dict[str, Any]]
 def _call_kernel(operation: str, params: dict[str, Any]) -> dict[str, Any]:
     """Call the kernel service over HTTP and return the response dict."""
     import httpx
+    print("_call_kernel: ", operation, params)
 
     url = f"{_KERNEL_URL}/operations/{operation}"
     response = httpx.post(url, json={"payload": params}, timeout=30.0)

--- a/opencad_kernel/api.py
+++ b/opencad_kernel/api.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query
@@ -209,6 +213,7 @@ def get_mesh(
     try:
         return _KERNEL.tessellate(shape_id, deflection)
     except NotImplementedError as exc:
+        print(exc)
         raise HTTPException(status_code=501, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/opencad_kernel/core/occt_backend.py
+++ b/opencad_kernel/core/occt_backend.py
@@ -68,6 +68,7 @@ GProp_GProps = None
 TopAbs_EDGE = None
 TopAbs_FACE = None
 TopAbs_WIRE = None
+TopAbs_REVERSED = None
 TopExp_Explorer = None
 TopLoc_Location = None
 TopoDS = None
@@ -133,6 +134,7 @@ if HAS_OCCT:  # pragma: no branch
     TopAbs_EDGE = topabs_mod.TopAbs_EDGE
     TopAbs_FACE = topabs_mod.TopAbs_FACE
     TopAbs_WIRE = topabs_mod.TopAbs_WIRE
+    TopAbs_REVERSED = topabs_mod.TopAbs_REVERSED
 
     TopExp_Explorer = importlib.import_module("OCP.TopExp").TopExp_Explorer
     TopLoc_Location = importlib.import_module("OCP.TopLoc").TopLoc_Location
@@ -428,15 +430,23 @@ def _tessellate_shape(shape: Any, deflection: float = 0.1) -> MeshData:
         else:
             normals.extend([0.0, 0.0, 0.0] * nb_nodes)
 
-        # Triangles
+        # Triangles — reverse winding for REVERSED faces so normals point outward
+        reversed_face = face.Orientation() == TopAbs_REVERSED
         for i in range(1, nb_tris + 1):
             tri = triangulation.Triangle(i)
             n1, n2, n3 = tri.Get()
-            faces.extend([
-                n1 - 1 + vertex_offset,
-                n2 - 1 + vertex_offset,
-                n3 - 1 + vertex_offset,
-            ])
+            if reversed_face:
+                faces.extend([
+                    n1 - 1 + vertex_offset,
+                    n3 - 1 + vertex_offset,
+                    n2 - 1 + vertex_offset,
+                ])
+            else:
+                faces.extend([
+                    n1 - 1 + vertex_offset,
+                    n2 - 1 + vertex_offset,
+                    n3 - 1 + vertex_offset,
+                ])
 
         vertex_offset += nb_nodes
         explorer.Next()
@@ -483,10 +493,14 @@ def _tessellate_face(shape: Any, face_index: int, deflection: float = 0.1) -> tu
                 else:
                     norms.extend([0.0, 0.0, 0.0] * nb_nodes)
 
+                reversed_face = face.Orientation() == TopAbs_REVERSED
                 for i in range(1, nb_tris + 1):
                     tri = triangulation.Triangle(i)
                     n1, n2, n3 = tri.Get()
-                    tris.extend([n1 - 1, n2 - 1, n3 - 1])
+                    if reversed_face:
+                        tris.extend([n1 - 1, n3 - 1, n2 - 1])
+                    else:
+                        tris.extend([n1 - 1, n2 - 1, n3 - 1])
 
                 mesh = MeshData(vertices=verts, faces=tris, normals=norms)
 

--- a/opencad_solver/api.py
+++ b/opencad_solver/api.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
 from typing import Any
 
 from fastapi import FastAPI

--- a/opencad_tree/api.py
+++ b/opencad_tree/api.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+
+from dotenv import load_dotenv
+
+load_dotenv()
 import json
 import logging
 import os

--- a/opencad_viewport/src/App.tsx
+++ b/opencad_viewport/src/App.tsx
@@ -138,8 +138,13 @@ export default function App(): JSX.Element {
             ...request,
             tree_state: tree,
           });
-          setTree(response.new_tree_state);
-          const latestNodeId = getLatestGeneratedNodeId(tree, response.new_tree_state, response.operations_executed);
+          const nextTree = response.new_tree_state;
+          const liveShapeIds = new Set(
+            Object.values(nextTree.nodes).map((n) => n.shape_id).filter(Boolean)
+          );
+          setMeshes((current) => current.filter((mesh) => liveShapeIds.has(mesh.shapeId)));
+          setTree(nextTree);
+          const latestNodeId = getLatestGeneratedNodeId(tree, nextTree, response.operations_executed);
           if (latestNodeId) {
             setSelectedNodeId(latestNodeId);
           }

--- a/opencad_viewport/src/mock/mockData.ts
+++ b/opencad_viewport/src/mock/mockData.ts
@@ -18,18 +18,24 @@ const vertices = [
 ];
 
 const faces = [
-  0, 1, 2,
-  0, 2, 3,
-  4, 6, 5,
-  4, 7, 6,
-  0, 4, 5,
-  0, 5, 1,
-  1, 5, 6,
-  1, 6, 2,
-  2, 6, 7,
-  2, 7, 3,
-  3, 7, 4,
-  3, 4, 0
+  // bottom (z=0, normal -Z)
+  0, 3, 2,
+  0, 2, 1,
+  // top (z=8, normal +Z)
+  4, 5, 6,
+  4, 6, 7,
+  // front (y=-12, normal -Y)
+  0, 1, 5,
+  0, 5, 4,
+  // right (x=+20, normal +X)
+  1, 2, 6,
+  1, 6, 5,
+  // back (y=+12, normal +Y)
+  2, 3, 7,
+  2, 7, 6,
+  // left (x=-20, normal -X)
+  3, 0, 4,
+  3, 4, 7,
 ];
 
 export const mockMeshes: MeshPayload[] = [


### PR DESCRIPTION
## Agent Harness:

Previously, the environment variables were not correctly read to harness with the LLMs

Now after setting backend kernel to `OPENCAD_SOLVER_BACKEND=occt`, and setting the `ANTHROPIC_API_KEY`, `OPENCAD_LLM_MODEL`, and `OPENCAD_LLM_PROVIDER`, in the env variables, we can see the agent generate the cad program, and visualize it in the view port.

## Face orientation:

Fixed the cube faces pointing incorrectly. This just involved just changing the permuatation of the vertices for the cube in the occt backend.