### PR TITLE
fixed cors in backend/api.py

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,10 +1,19 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from opencad_kernel import api as kernel_api
 from opencad_agent import api as agent_api
 from opencad_solver import api as solver_api
 from opencad_tree import api as tree_api
 
 app = FastAPI(title="OpenCAD API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],           # Allows all origins
+    allow_credentials=True,
+    allow_methods=["*"],           # Allows all methods (GET, POST, OPTIONS, etc.)
+    allow_headers=["*"],           # Allows all headers
+)
 
 # Mount each sub-module with a clear namespace
 app.include_router(kernel_api.router, prefix="/kernel", tags=["Kernel"])


### PR DESCRIPTION
## PR Title: 
`feat: enable CORS middleware to allow cross-origin requests`

## Description
This PR adds `CORSMiddleware` to the FastAPI application. Currently, the frontend is unable to communicate with the backend services due to browser-enforced CORS (Cross-Origin Resource Sharing) policies. 

When the frontend attempts to send a `POST` request with a JSON body, the browser sends a preflight `OPTIONS` request. Without this middleware, the server responds with a `405 Method Not Allowed`, preventing the actual API call from executing.

### Changes
* Imported `CORSMiddleware` from `fastapi.middleware.cors`.
* Configured the middleware to allow all origins, methods, and headers (currently optimized for development).
* Ensured the middleware is initialized before the sub-module routers are included.

## Testing Instructions
1. Start the backend server.
2. Attempt to trigger a chat request or any other POST endpoint from the frontend application.
3. Verify that the browser console no longer shows `405 Method Not Allowed` for `OPTIONS` requests.
4. Confirm the `POST` request successfully reaches the `/agent/chat` endpoint.

## Security Note
Currently, `allow_origins` is set to `["*"]`. Before moving to production, we should restrict this to the specific domain(s) where our frontend is hosted to adhere to the principle of least privilege.
