### PR TITLE
added script the run dev and modified the baseUrl port to standard 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ cd /backend
 python3 -m uvicorn api:app --reload --port 8000
 ```
 
+### Run the dev script
+
+To start the backend and frontend together from the repository root:
+
+```bash
+npm install --prefix opencad_viewport
+./scripts/run_dev.sh
+```
+
+This starts:
+
+- backend: `http://127.0.0.1:8000`
+- frontend: `http://127.0.0.1:5173`
+
+Press `Ctrl+C` to stop both services.
+
+Optional environment overrides:
+
+```bash
+BACKEND_HOST=0.0.0.0 BACKEND_PORT=8000 FRONTEND_HOST=0.0.0.0 FRONTEND_PORT=5173 ./scripts/run_dev.sh
+```
+
 ### 3. Check health
 
 ```bash

--- a/opencad_viewport/.env.example
+++ b/opencad_viewport/.env.example
@@ -8,3 +8,4 @@ VITE_USE_CHAT_MOCK=false
 
 # Example of what a real API key would look like
 # VITE_API_URL=https://api.example.com
+VITE_BASE_URL=http://127.0.0.1:8000

--- a/opencad_viewport/src/api/client.ts
+++ b/opencad_viewport/src/api/client.ts
@@ -27,7 +27,7 @@ export class OpenCadApiClient {
   private readonly useChatMock: boolean;
 
   constructor(
-    baseUrl = "http://127.0.0.1:8003",
+    baseUrl = import.meta.env.VITE_BASE_URL ?? "http://127.0.0.1:8000",
     kernelUrl?: string,
     useMock = import.meta.env.VITE_USE_MOCK !== "false",
     useChatMock = import.meta.env.VITE_USE_CHAT_MOCK === "true",

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/opencad_viewport"
+
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "Backend directory not found: $BACKEND_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -d "$FRONTEND_DIR" ]]; then
+  echo "Frontend directory not found: $FRONTEND_DIR" >&2
+  exit 1
+fi
+
+backend_pid=""
+frontend_pid=""
+
+cleanup() {
+  local exit_code=$?
+
+  if [[ -n "$backend_pid" ]] && kill -0 "$backend_pid" 2>/dev/null; then
+    kill "$backend_pid" 2>/dev/null || true
+  fi
+
+  if [[ -n "$frontend_pid" ]] && kill -0 "$frontend_pid" 2>/dev/null; then
+    kill "$frontend_pid" 2>/dev/null || true
+  fi
+
+  wait "$backend_pid" "$frontend_pid" 2>/dev/null || true
+  exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+echo "Starting backend on http://$BACKEND_HOST:$BACKEND_PORT"
+(
+  cd "$BACKEND_DIR"
+  python3 -m uvicorn api:app --reload --host "$BACKEND_HOST" --port "$BACKEND_PORT"
+) &
+backend_pid=$!
+
+echo "Starting frontend on http://$FRONTEND_HOST:$FRONTEND_PORT"
+(
+  cd "$FRONTEND_DIR"
+  npm run dev -- --host "$FRONTEND_HOST" --port "$FRONTEND_PORT"
+) &
+frontend_pid=$!
+
+echo "Backend PID: $backend_pid"
+echo "Frontend PID: $frontend_pid"
+echo "Press Ctrl+C to stop both services."
+
+wait -n "$backend_pid" "$frontend_pid"


### PR DESCRIPTION
## Summary
- add `scripts/run_dev.sh` to start the backend and frontend together for local development
- update `README.md` with short instructions for running the dev script from the repository root
- align local development defaults with backend port `8000`
## Testing
- not run
Suggested PR title:
Add dev startup script and README instructions