### PR TITLE
removed mocked mesh, sketch, tree from inital ui

### DIFF
--- a/opencad_viewport/src/App.tsx
+++ b/opencad_viewport/src/App.tsx
@@ -4,7 +4,8 @@ import { ChatPanel } from "./components/ChatPanel";
 import { FeatureTreePanel } from "./components/FeatureTreePanel";
 import { SketchEditor } from "./components/SketchEditor";
 import { Viewport3D } from "./components/Viewport3D";
-import { mockFeatureTree, mockMeshes, mockSketch } from "./mock/mockData";
+import { mockMeshes } from "./mock/mockData";
+import { createEmptyTree, createEmptySketch } from "./types";
 import type { ChatOperationExecution, FeatureNodeView, FeatureTreeView, MeshPayload, SketchPayload } from "./types";
 
 const FALLBACK_MESH_Y_OFFSET_SCALE = 0.35;
@@ -56,9 +57,9 @@ function createFallbackMesh(node: FeatureNodeView, index: number): MeshPayload {
 
 export default function App(): JSX.Element {
   const api = useMemo(() => new OpenCadApiClient(), []);
-  const [tree, setTree] = useState<FeatureTreeView>(mockFeatureTree);
-  const [meshes, setMeshes] = useState<MeshPayload[]>(mockMeshes);
-  const [sketch, setSketch] = useState<SketchPayload>(mockSketch);
+  const [tree, setTree] = useState<FeatureTreeView>(createEmptyTree);
+  const [meshes, setMeshes] = useState<MeshPayload[]>([]);
+  const [sketch, setSketch] = useState<SketchPayload>(createEmptySketch);
   const [selectedNodeId, setSelectedNodeId] = useState<string>(tree.root_id);
 
   const selectedShapeId = tree.nodes[selectedNodeId]?.shape_id ?? null;

--- a/opencad_viewport/src/types.ts
+++ b/opencad_viewport/src/types.ts
@@ -37,6 +37,16 @@ export interface FeatureTreeView {
   revision: number;
 }
 
+export function createEmptyTree(): FeatureTreeView {
+  return {
+    root_id: "root",
+    active_branch: "main",
+    revision: 0,
+    nodes: {
+    },
+  };
+}
+
 export interface MeshPayload {
   shapeId: string;
   vertices: number[] | Float32Array;
@@ -82,6 +92,10 @@ export interface SketchConstraint {
 export interface SketchPayload {
   entities: Record<string, SketchEntity>;
   constraints: SketchConstraint[];
+}
+
+export function createEmptySketch(): SketchPayload {
+  return { entities: {}, constraints: [] };
 }
 
 export interface SolverResult {


### PR DESCRIPTION
## fixed the initial UI state to not include the mocked data
<img width="1895" height="1028" alt="image" src="https://github.com/user-attachments/assets/3d2fcc4b-0866-40b1-91b2-d93147952501" />
