### PR TITLE
Reject unsupported CAD prompts

### DIFF
--- a/backend/opencad_agent/api.py
+++ b/backend/opencad_agent/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI, HTTPException
 
 load_dotenv()
 router = APIRouter()
@@ -9,6 +9,7 @@ router = APIRouter()
 from opencad.api_app import create_api_app
 from opencad.version import __version__
 from opencad_agent.models import ChatRequest, ChatResponse
+from opencad_agent.planner import UnsupportedPromptError
 from opencad_agent.service import OpenCadAgentService
 
 app: FastAPI = create_api_app(title="OpenCAD Agent", version=__version__)
@@ -22,7 +23,10 @@ def healthz() -> dict[str, str]:
 
 @router.post("/chat", response_model=ChatResponse)
 def chat(request: ChatRequest) -> ChatResponse:
-    return _service.chat(request)
+    try:
+        return _service.chat(request)
+    except UnsupportedPromptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 app.include_router(router)

--- a/backend/opencad_agent/planner.py
+++ b/backend/opencad_agent/planner.py
@@ -6,6 +6,10 @@ from opencad_agent.models import OperationExecution
 from opencad_agent.tools import ToolRuntime
 
 
+class UnsupportedPromptError(ValueError):
+    """Raised when no deterministic planner or local code template matches a prompt."""
+
+
 class OpenCadPlanner:
     def execute(self, message: str, runtime: ToolRuntime, reasoning: bool = False) -> tuple[str, list[OperationExecution]]:
         lowered = message.lower()
@@ -21,11 +25,10 @@ class OpenCadPlanner:
                 response = "Mounting bracket feature sequence generated and executed."
             return response, operations
 
-        operations = self._build_simple_feature(runtime)
-        response = "Executed a minimal sketch-to-extrude sequence for the request."
-        if reasoning:
-            response = "Plan: create sketch then extrude. Sequence executed with dependency-safe IDs."
-        return response, operations
+        raise UnsupportedPromptError(
+            "Unsupported CAD request. The built-in planner only supports the mounting-bracket workflow. "
+            "Enable Generate Code with a configured OPENCAD_LLM_MODEL for arbitrary requests."
+        )
 
     def _safe_call(
         self,
@@ -42,39 +45,6 @@ class OpenCadPlanner:
             error = {"error": str(exc)}
             operations.append(OperationExecution(tool=tool, status="error", arguments=arguments, result=error))
             raise
-
-    def _build_simple_feature(self, runtime: ToolRuntime) -> list[OperationExecution]:
-        operations: list[OperationExecution] = []
-
-        base_sketch_args = {
-            "name": "Simple Base Sketch",
-            "entities": {
-                "l1": {"id": "l1", "type": "line", "start": (0.0, 0.0), "end": (30.0, 0.0)},
-                "l2": {"id": "l2", "type": "line", "start": (30.0, 0.0), "end": (30.0, 20.0)},
-                "l3": {"id": "l3", "type": "line", "start": (30.0, 20.0), "end": (0.0, 20.0)},
-                "l4": {"id": "l4", "type": "line", "start": (0.0, 20.0), "end": (0.0, 0.0)},
-            },
-            "profile_order": ["l1", "l2", "l3", "l4"],
-            "constraints": [{"id": "d1", "type": "distance", "a": "l1", "value": 30.0}],
-        }
-
-        sketch = self._safe_call(
-            operations,
-            "add_sketch",
-            base_sketch_args,
-            lambda: {"sketch_id": runtime.add_sketch(**base_sketch_args)},
-        )
-        sketch_id = str(sketch["sketch_id"])
-
-        extrude_args = {"sketch_id": sketch_id, "depth": 8.0, "name": "Simple Extrude"}
-        self._safe_call(
-            operations,
-            "extrude",
-            extrude_args,
-            lambda: {"feature_id": runtime.extrude(**extrude_args)},
-        )
-
-        return operations
 
     def _build_mounting_bracket(self, runtime: ToolRuntime) -> list[OperationExecution]:
         operations: list[OperationExecution] = []
@@ -262,12 +232,7 @@ class OpenCadPlanner:
                 ")\n"
             )
 
-        return (
-            '"""Smoke test: rectangle with circular hole."""\n'
-            "from opencad import Part, Sketch\n\n"
-            'rect_profile = Sketch(name="Outer").rect(30, 20)\n'
-            'hole_profile = Sketch(name="Hole").circle(4, center=(15, 10))\n\n'
-            'slab = Part(name="Slab").extrude(rect_profile, depth=8, name="Slab Body")\n'
-            'hole = Part(name="Hole").extrude(hole_profile, depth=8, name="Hole Body")\n'
-            'final = slab.cut(hole, name="Final Part")\n'
+        raise UnsupportedPromptError(
+            "Unsupported code-generation request. The built-in generator only supports mounting brackets "
+            "and PCB carriers. Configure OPENCAD_LLM_MODEL for arbitrary requests."
         )

--- a/backend/opencad_agent/tests/test_agent.py
+++ b/backend/opencad_agent/tests/test_agent.py
@@ -10,7 +10,7 @@ from opencad_agent.api import app
 from opencad_agent.generated_code import GeneratedCodePolicyError, validate_generated_code
 from opencad_agent.llm import LiteLlmProvider
 from opencad_agent.models import ChatRequest
-from opencad_agent.planner import OpenCadPlanner
+from opencad_agent.planner import OpenCadPlanner, UnsupportedPromptError
 from opencad_agent.prompting import build_code_generation_prompt, build_system_prompt
 from opencad_agent.service import OpenCadAgentService
 from opencad_agent.tools import ToolRuntime
@@ -59,15 +59,36 @@ def test_code_generation_prompt_contains_example_scripts() -> None:
 @pytest.mark.parametrize(
     ("message", "expected"),
     [
-        ("Generate a mounting bracket script", "Generated Mounting Bracket"),
-        ("Generate a PCB carrier script", "Generated PCB Carrier"),
-        ("Generate a simple part", "Generated Part"),
+        ("Generate a mounting bracket script", "Mounting bracket"),
+        ("Generate a PCB carrier script", "PCB carrier"),
     ],
 )
 def test_planner_generate_code_returns_example_style_scripts(message: str, expected: str) -> None:
     code = OpenCadPlanner().generate_code(message)
     assert "from opencad import Part, Sketch" in code
     assert expected in code
+
+
+@pytest.mark.parametrize("generate_code", [False, True])
+def test_chat_api_rejects_unsupported_prompts(generate_code: bool) -> None:
+    client = TestClient(app)
+    payload = {
+        "message": "Build a cog",
+        "tree_state": _seed_tree().model_dump(),
+        "conversation_history": [],
+        "reasoning": False,
+        "generate_code": generate_code,
+    }
+
+    response = client.post("/chat", json=payload)
+
+    assert response.status_code == 422
+    assert "Unsupported" in response.json()["detail"]
+
+
+def test_local_code_generator_raises_for_unsupported_prompt() -> None:
+    with pytest.raises(UnsupportedPromptError, match="Unsupported code-generation request"):
+        OpenCadPlanner().generate_code("Build a cog")
 
 
 def test_mounting_bracket_prompt_generates_minimum_operations() -> None:

--- a/opencad_viewport/src/api/client.test.ts
+++ b/opencad_viewport/src/api/client.test.ts
@@ -7,6 +7,7 @@ vi.mock("axios", () => ({
   default: {
     post: vi.fn(),
     get: vi.fn(),
+    isAxiosError: vi.fn(),
   },
 }));
 
@@ -52,6 +53,21 @@ describe("OpenCadApiClient routes", () => {
     expect(mockedAxios.get).toHaveBeenCalledWith("http://127.0.0.1:8003/kernel/shapes/shape-1/mesh", {
       params: { deflection: 0.2 },
     });
+  });
+
+  it("surfaces an unsupported-prompt detail from the agent API", async () => {
+    const error = { response: { data: { detail: "Unsupported CAD request." } } };
+    mockedAxios.post.mockRejectedValue(error);
+    mockedAxios.isAxiosError.mockReturnValue(true);
+
+    const client = new OpenCadApiClient("http://127.0.0.1:8003", undefined, false, false);
+
+    await expect(client.sendChat({
+      message: "Build a cog",
+      tree_state: { nodes: {}, root_id: "root", active_branch: "main", revision: 0 },
+      conversation_history: [],
+      generate_code: true,
+    })).rejects.toThrow("Unsupported CAD request.");
   });
 
   it("uses custom kernel URL for streaming mesh events", () => {

--- a/opencad_viewport/src/api/client.ts
+++ b/opencad_viewport/src/api/client.ts
@@ -56,8 +56,18 @@ export class OpenCadApiClient {
       };
     }
 
-    const response = await axios.post<ChatResponsePayload>(`${this.baseUrl}/agent/chat`, request);
-    return response.data;
+    try {
+      const response = await axios.post<ChatResponsePayload>(`${this.baseUrl}/agent/chat`, request);
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const detail = error.response?.data?.detail;
+        if (typeof detail === "string") {
+          throw new Error(detail);
+        }
+      }
+      throw error;
+    }
   }
 
   async getTree(treeId: string): Promise<FeatureTreeView> {


### PR DESCRIPTION
## Summary
- remove generic geometry fallbacks for unsupported prompts
- return HTTP 422 with a clear unsupported-request message
- surface backend error details in the chat UI
- cover both Generate Code modes and client error handling

## Validation
- 5 focused backend tests passed
- 4 frontend API client tests passed
- frontend production build passed