### PR TITLE
Remove fake code generation fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Geometry and solver backends
+OPENCAD_KERNEL_BACKEND=analytic
+OPENCAD_SOLVER_BACKEND=python
+
+# Use the mounted kernel for agent-generated and feature-tree geometry
+OPENCAD_AGENT_LIVE_KERNEL=true
+OPENCAD_TREE_LIVE_KERNEL=true
+
+# Optional local LLM code generation through Ollama
+# Install with: uv sync --extra llm
+# Pull a model with: ollama pull qwen2.5-coder:7b
+# OPENCAD_LLM_PROVIDER=ollama
+# OPENCAD_LLM_MODEL=qwen2.5-coder:7b
+# OLLAMA_API_BASE=http://127.0.0.1:11434

--- a/backend/opencad_agent/api.py
+++ b/backend/opencad_agent/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI, HTTPException
 
 load_dotenv()
 router = APIRouter()
@@ -9,7 +9,14 @@ router = APIRouter()
 from opencad.api_app import create_api_app
 from opencad.version import __version__
 from opencad_agent.models import ChatRequest, ChatResponse
-from opencad_agent.service import OpenCadAgentService
+from opencad_agent.planner import UnsupportedPromptError
+from opencad_agent.service import (
+    AgentConfigurationError,
+    GeneratedCodeExecutionError,
+    GeneratedCodeValidationError,
+    LlmGenerationError,
+    OpenCadAgentService,
+)
 
 app: FastAPI = create_api_app(title="OpenCAD Agent", version=__version__)
 _service = OpenCadAgentService()
@@ -22,7 +29,14 @@ def healthz() -> dict[str, str]:
 
 @router.post("/chat", response_model=ChatResponse)
 def chat(request: ChatRequest) -> ChatResponse:
-    return _service.chat(request)
+    try:
+        return _service.chat(request)
+    except AgentConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except LlmGenerationError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except (GeneratedCodeExecutionError, GeneratedCodeValidationError, UnsupportedPromptError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 app.include_router(router)

--- a/backend/opencad_agent/generated_code.py
+++ b/backend/opencad_agent/generated_code.py
@@ -69,6 +69,7 @@ def validate_generated_code(code: str) -> ast.Module:
 
     for node in ast.walk(tree):
         _validate_node(node)
+    _validate_sketch_profiles(tree)
     return tree
 
 
@@ -126,6 +127,16 @@ def _validate_call(node: ast.Call) -> None:
     root_name = _attribute_root_name(node.func)
     if root_name in BLOCKED_MODULE_NAMES:
         raise GeneratedCodePolicyError(f"Generated code cannot call APIs on {root_name!r}.")
+    if call_name == "circle":
+        for keyword in node.keywords:
+            if (
+                keyword.arg == "subtract"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+            ):
+                raise GeneratedCodePolicyError(
+                    "Generated sketches cannot use subtract=True; create a separate solid and use Part.cut()."
+                )
 
 
 def _call_name(node: ast.AST) -> str | None:
@@ -145,6 +156,59 @@ def _attribute_root_name(node: ast.AST) -> str | None:
     if isinstance(current, ast.Name):
         return current.id
     return None
+
+
+def _validate_sketch_profiles(tree: ast.Module) -> None:
+    """Reject sketch call sequences that the live kernel cannot form into one wire."""
+    sketch_calls: dict[str, list[str]] = {}
+
+    for statement in tree.body:
+        value: ast.AST | None = None
+        assigned_name: str | None = None
+        if isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+            target = statement.targets[0]
+            if isinstance(target, ast.Name):
+                assigned_name = target.id
+                value = statement.value
+        elif isinstance(statement, ast.Expr):
+            value = statement.value
+
+        if value is None:
+            continue
+
+        root_name = _attribute_root_name(value)
+        calls = [
+            call_name
+            for call in ast.walk(value)
+            if isinstance(call, ast.Call)
+            and (call_name := _call_name(call.func)) in {"arc", "circle", "line", "rect"}
+        ]
+
+        if assigned_name is not None and _contains_constructor(value, "Sketch"):
+            sketch_calls[assigned_name] = calls
+            _check_sketch_call_sequence(calls)
+            continue
+
+        if root_name in sketch_calls and calls:
+            sketch_calls[root_name].extend(calls)
+            _check_sketch_call_sequence(sketch_calls[root_name])
+
+
+def _contains_constructor(node: ast.AST, constructor_name: str) -> bool:
+    return any(
+        isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Name)
+        and item.func.id == constructor_name
+        for item in ast.walk(node)
+    )
+
+
+def _check_sketch_call_sequence(calls: list[str]) -> None:
+    closed_profiles = [name for name in calls if name in {"circle", "rect"}]
+    if len(closed_profiles) > 1 or (closed_profiles and any(name in {"arc", "line"} for name in calls)):
+        raise GeneratedCodePolicyError(
+            "Each Sketch must contain exactly one connected profile; use separate sketches and Part booleans."
+        )
 
 
 def _execution_namespace() -> dict[str, Any]:

--- a/backend/opencad_agent/llm.py
+++ b/backend/opencad_agent/llm.py
@@ -20,6 +20,12 @@ def _default_completion(**kwargs: Any) -> Any:
     return completion(**kwargs)
 
 
+def _resolve_model_name(provider: str | None, model: str) -> str:
+    if provider and "/" not in model:
+        return f"{provider}/{model}"
+    return model
+
+
 def _strip_code_fences(code: str) -> str:
     code = code.strip()
     if code.startswith("```python"):
@@ -62,6 +68,7 @@ class LiteLlmProvider:
     def generate_code(
         self,
         *,
+        provider: str | None,
         model: str,
         system_prompt: str,
         user_message: str,
@@ -71,11 +78,17 @@ class LiteLlmProvider:
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend({"role": item.role, "content": item.content} for item in conversation_history)
         messages.append({"role": "user", "content": user_message})
-        response = self._completion(
-            model=model,
-            messages=messages,
-            temperature=HIGH_REASONING_CODE_TEMPERATURE if reasoning else DEFAULT_CODE_TEMPERATURE,
-        )
+        resolved_model = _resolve_model_name(provider, model)
+        completion_options: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "temperature": HIGH_REASONING_CODE_TEMPERATURE if reasoning else DEFAULT_CODE_TEMPERATURE,
+            "max_tokens": 1600,
+            "seed": 0,
+        }
+        if resolved_model.startswith("ollama/"):
+            completion_options["reasoning_effort"] = "high" if reasoning else "none"
+        response = self._completion(**completion_options)
         logger.debug("Received LLM code-generation response")
         cleaned_response = _strip_code_fences(_extract_message_content(response))
         return cleaned_response

--- a/backend/opencad_agent/models.py
+++ b/backend/opencad_agent/models.py
@@ -17,7 +17,15 @@ class ChatRequest(BaseModel):
     tree_state: FeatureTree
     conversation_history: list[ChatHistoryItem] = Field(default_factory=list)
     reasoning: bool = False
+    llm_provider: str | None = None
+    llm_model: str | None = None
     generate_code: bool = False
+
+    @model_validator(mode="after")
+    def _validate_llm_configuration(self) -> ChatRequest:
+        if self.llm_provider and not self.llm_model:
+            raise ValueError("llm_model is required when llm_provider is set.")
+        return self
 
 
 

--- a/backend/opencad_agent/planner.py
+++ b/backend/opencad_agent/planner.py
@@ -6,6 +6,10 @@ from opencad_agent.models import OperationExecution
 from opencad_agent.tools import ToolRuntime
 
 
+class UnsupportedPromptError(ValueError):
+    """Raised when the deterministic planner does not support a prompt."""
+
+
 class OpenCadPlanner:
     def execute(self, message: str, runtime: ToolRuntime, reasoning: bool = False) -> tuple[str, list[OperationExecution]]:
         lowered = message.lower()
@@ -21,11 +25,9 @@ class OpenCadPlanner:
                 response = "Mounting bracket feature sequence generated and executed."
             return response, operations
 
-        operations = self._build_simple_feature(runtime)
-        response = "Executed a minimal sketch-to-extrude sequence for the request."
-        if reasoning:
-            response = "Plan: create sketch then extrude. Sequence executed with dependency-safe IDs."
-        return response, operations
+        raise UnsupportedPromptError(
+            "This request is not supported by the deterministic planner. Enable Generate Code to use the LLM."
+        )
 
     def _safe_call(
         self,
@@ -42,39 +44,6 @@ class OpenCadPlanner:
             error = {"error": str(exc)}
             operations.append(OperationExecution(tool=tool, status="error", arguments=arguments, result=error))
             raise
-
-    def _build_simple_feature(self, runtime: ToolRuntime) -> list[OperationExecution]:
-        operations: list[OperationExecution] = []
-
-        base_sketch_args = {
-            "name": "Simple Base Sketch",
-            "entities": {
-                "l1": {"id": "l1", "type": "line", "start": (0.0, 0.0), "end": (30.0, 0.0)},
-                "l2": {"id": "l2", "type": "line", "start": (30.0, 0.0), "end": (30.0, 20.0)},
-                "l3": {"id": "l3", "type": "line", "start": (30.0, 20.0), "end": (0.0, 20.0)},
-                "l4": {"id": "l4", "type": "line", "start": (0.0, 20.0), "end": (0.0, 0.0)},
-            },
-            "profile_order": ["l1", "l2", "l3", "l4"],
-            "constraints": [{"id": "d1", "type": "distance", "a": "l1", "value": 30.0}],
-        }
-
-        sketch = self._safe_call(
-            operations,
-            "add_sketch",
-            base_sketch_args,
-            lambda: {"sketch_id": runtime.add_sketch(**base_sketch_args)},
-        )
-        sketch_id = str(sketch["sketch_id"])
-
-        extrude_args = {"sketch_id": sketch_id, "depth": 8.0, "name": "Simple Extrude"}
-        self._safe_call(
-            operations,
-            "extrude",
-            extrude_args,
-            lambda: {"feature_id": runtime.extrude(**extrude_args)},
-        )
-
-        return operations
 
     def _build_mounting_bracket(self, runtime: ToolRuntime) -> list[OperationExecution]:
         operations: list[OperationExecution] = []
@@ -213,61 +182,3 @@ class OpenCadPlanner:
         )
 
         return operations
-
-    def generate_code(self, message: str) -> str:
-        lowered = message.lower()
-        if "mounting bracket" in lowered:
-            return (
-                '"""Mounting bracket with fastener holes and center cutout."""\n'
-                "from opencad import Part, Sketch\n\n"
-                'plate = Part(name="Plate").extrude(\n'
-                '    Sketch(name="Plate Outline").rect(80, 30),\n'
-                '    depth=4, name="Plate Body",\n'
-                ")\n"
-                'h1 = Part(name="Hole TL").extrude(Sketch(name="HTL").circle(3, center=(8, 22)), depth=4, name="HTL Body")\n'
-                'h2 = Part(name="Hole TR").extrude(Sketch(name="HTR").circle(3, center=(72, 22)), depth=4, name="HTR Body")\n'
-                'h3 = Part(name="Hole BL").extrude(Sketch(name="HBL").circle(3, center=(8, 8)), depth=4, name="HBL Body")\n'
-                'h4 = Part(name="Hole BR").extrude(Sketch(name="HBR").circle(3, center=(72, 8)), depth=4, name="HBR Body")\n'
-                'center = Part(name="Center").extrude(Sketch(name="C").circle(5, center=(40, 15)), depth=4, name="C Body")\n'
-                "bracket = plate.cut(h1).cut(h2).cut(h3).cut(h4).cut(center)\n"
-            )
-
-        if "pcb" in lowered or "carrier" in lowered:
-            return (
-                '"""PCB carrier plate with mounting holes and cable passthrough."""\n'
-                "from opencad import Part, Sketch\n\n"
-                # Outer plate: 90x60, 3mm thick
-                'plate = Part(name="Carrier Plate").extrude(\n'
-                '    Sketch(name="Carrier Outline").rect(90, 60),\n'
-                '    depth=3, name="Carrier Plate Body",\n'
-                ")\n\n"
-                # Four 2.2mm mounting holes at corners (4.4mm dia)\n'
-                'm1 = Part(name="Mount BL").extrude(Sketch(name="MBL").circle(2.2, center=(8, 8)), depth=3, name="MBL Body")\n'
-                'm2 = Part(name="Mount BR").extrude(Sketch(name="MBR").circle(2.2, center=(82, 8)), depth=3, name="MBR Body")\n'
-                'm3 = Part(name="Mount TL").extrude(Sketch(name="MTL").circle(2.2, center=(8, 52)), depth=3, name="MTL Body")\n'
-                'm4 = Part(name="Mount TR").extrude(Sketch(name="MTR").circle(2.2, center=(82, 52)), depth=3, name="MTR Body")\n\n'
-                # Center 7mm cable passthrough (14mm dia)\n'
-                'passthrough = Part(name="Cable Passthrough").extrude(\n'
-                '    Sketch(name="Passthrough Profile").circle(7, center=(45, 30)),\n'
-                '    depth=3, name="Passthrough Body",\n'
-                ")\n\n"
-                # Cut all holes, then offset for reinforcement\n'
-                "carrier = (\n"
-                '    plate.cut(m1, name="Cut Mount BL")\n'
-                '         .cut(m2, name="Cut Mount BR")\n'
-                '         .cut(m3, name="Cut Mount TL")\n'
-                '         .cut(m4, name="Cut Mount TR")\n'
-                '         .cut(passthrough, name="Cut Passthrough")\n'
-                '         .offset(0.4, name="Carrier Reinforcement")\n'
-                ")\n"
-            )
-
-        return (
-            '"""Smoke test: rectangle with circular hole."""\n'
-            "from opencad import Part, Sketch\n\n"
-            'rect_profile = Sketch(name="Outer").rect(30, 20)\n'
-            'hole_profile = Sketch(name="Hole").circle(4, center=(15, 10))\n\n'
-            'slab = Part(name="Slab").extrude(rect_profile, depth=8, name="Slab Body")\n'
-            'hole = Part(name="Hole").extrude(hole_profile, depth=8, name="Hole Body")\n'
-            'final = slab.cut(hole, name="Final Part")\n'
-        )

--- a/backend/opencad_agent/prompting.py
+++ b/backend/opencad_agent/prompting.py
@@ -55,13 +55,13 @@ def _load_example_scripts() -> str:
 
 _API_REFERENCE = """\
 Sketch methods (all return self for chaining):
-  Sketch(name=str, plane=str, origin=tuple)
+  Sketch(name=str, plane="XY", origin=(x,y,z))      # all constructor arguments are keyword-only
   .line(start=(x,y), end=(x,y))
   .rect(width, height, *, origin=(x,y))
-  .circle(radius, *, center=(x,y), subtract=bool)   # subtract cuts a hole in the profile
+  .circle(radius, *, center=(x,y))                  # one closed profile per sketch
 
 Part methods (all return self for chaining):
-  Part(name=str)
+  Part(name=str)                                     # constructor argument is keyword-only
   .box(length, width, height, *, name=str)
   .cylinder(radius, height, *, name=str)
   .sphere(radius, *, name=str)
@@ -74,6 +74,28 @@ Part methods (all return self for chaining):
   .linear_pattern(*, direction=(x,y,z), count, spacing, name=str)
   .circular_pattern(*, axis_origin=(x,y,z), axis_direction=(x,y,z), count, angle=360.0, name=str)
   .mirror(*, plane_origin=(x,y,z), plane_normal=(x,y,z), name=str)
+"""
+
+
+_COMPOSITION_EXAMPLE = """\
+Valid repeated-feature composition example:
+```python
+from opencad import Part, Sketch
+
+core = Part(name="Pattern Core").cylinder(radius=20, height=6, name="Core")
+feature_profile = Sketch(name="Radial Feature").rect(6, 6, origin=(18, -3))
+feature = Part(name="Feature").extrude(feature_profile, depth=6, name="Feature Body")
+features = feature.circular_pattern(
+    axis_origin=(0, 0, 0),
+    axis_direction=(0, 0, 1),
+    count=12,
+    angle=360,
+    name="Radial Pattern",
+)
+combined = core.union(features, name="Combined Body")
+opening = Part(name="Opening").cylinder(radius=5, height=6, name="Opening Tool")
+result = combined.cut(opening, name="Finished Part")
+```
 """
 
 
@@ -91,9 +113,18 @@ def build_code_generation_prompt(tree_state: FeatureTree) -> str:
         "- Keep the script self-contained and aligned with the examples below.\n"
         "- Do not use filesystem, network, subprocess, dynamic execution, functions, classes, loops, or imports other than `from opencad import Part, Sketch`.\n"
         "- Do not enclose the returned code with comment markers, or markers saying it's python, assume that the code is executed.\n"
+        "- Constructors are keyword-only: always write `Part(name=...)` and pass only named arguments to `Sketch(...)`.\n"
+        "- Prefer `Sketch(name=...)`; if origin is supplied it must be a 3-number tuple, while rect origin and circle center use 2-number tuples.\n"
+        "- Create each independent solid from its own Part instance; do not call an operation on a Part that has no shape.\n"
+        "- For radial repetition, sketch one feature away from the axis, extrude it, then use circular_pattern and union it with the core.\n"
+        "- For a cog or gear, make each tooth cross the core's outside radius so it visibly protrudes; do not put a hole in the tooth profile.\n"
+        "- Create holes as separate solid tools and subtract them with cut.\n"
+        "- Never use `subtract=True` in a Sketch; the live kernel requires a separate solid tool and cut.\n"
+        "- Each Sketch variable may call exactly one `rect` or exactly one `circle`, never both and never twice.\n"
         "\n"
         "API reference (use ONLY these signatures — do not invent parameters):\n"
         f"{_API_REFERENCE}\n"
+        f"{_COMPOSITION_EXAMPLE}\n"
         "Reference examples:\n"
         f"{examples}\n"
     )

--- a/backend/opencad_agent/service.py
+++ b/backend/opencad_agent/service.py
@@ -15,6 +15,22 @@ from opencad_tree.models import FeatureTree
 logger = logging.getLogger(__name__)
 
 
+class AgentConfigurationError(RuntimeError):
+    """Raised when code generation is requested without an LLM model."""
+
+
+class LlmGenerationError(RuntimeError):
+    """Raised when the configured LLM cannot return usable code."""
+
+
+class GeneratedCodeExecutionError(RuntimeError):
+    """Raised when generated code cannot be validated or executed."""
+
+
+class GeneratedCodeValidationError(RuntimeError):
+    """Raised when generated code fails an isolated in-process dry run."""
+
+
 class OpenCadAgentService:
     def __init__(
         self,
@@ -39,6 +55,21 @@ class OpenCadAgentService:
 
         if request.generate_code:
             generated_code = self._generate_code(request)
+            try:
+                self._validate_generated_code(generated_code, request.tree_state)
+            except GeneratedCodeValidationError as exc:
+                generated_code = self._generate_code(
+                    request,
+                    user_message=(
+                        f"Correct the previous code for this request: {request.message}\n\n"
+                        f"Validation error: {exc}\n\n"
+                        f"Invalid code:\n{generated_code}\n\n"
+                        "For every Sketch variable, keep exactly one closed-profile call: one rect or one circle. "
+                        "Delete all extra closed-profile calls instead of replacing them. "
+                        "Return only corrected OpenCAD Python code."
+                    ),
+                )
+                self._validate_generated_code(generated_code, request.tree_state)
             new_tree, operations = self._run_generated_code(generated_code, request.tree_state)
             return ChatResponse(
                 response=generated_code,
@@ -80,24 +111,10 @@ class OpenCadAgentService:
         ctx._sync_counters()
         prior_nodes = set(ctx.tree.nodes.keys())
 
-        self._execute_code_in_context(code, ctx)
-
-        # try:
-        #     self._execute_code_in_context(code, ctx)
-        # except Exception as exc:
-        #     import httpx
-        #     if kernel_call_fn is not None and isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError, httpx.TimeoutException)):
-        #         # Kernel unreachable — fall back to in-process and re-run
-        #         ctx = RuntimeContext()
-        #         ctx.tree = deepcopy(tree_state)
-        #         ctx._sync_counters()
-        #         prior_nodes = set(ctx.tree.nodes.keys())
-        #         try:
-        #             self._execute_code_in_context(code, ctx)
-        #         except Exception as exc2:
-        #             raise RuntimeError(f"Generated code execution failed: {exc2}") from exc2
-        #     else:
-        #         raise RuntimeError(f"Generated code execution failed: {exc}") from exc
+        try:
+            self._execute_code_in_context(code, ctx)
+        except Exception as exc:
+            raise GeneratedCodeExecutionError(f"Generated code execution failed: {exc}") from exc
 
         operations: list[OperationExecution] = []
         for node_id, node in ctx.tree.nodes.items():
@@ -113,6 +130,18 @@ class OpenCadAgentService:
 
         return ctx.tree, operations
 
+    def _validate_generated_code(self, code: str, tree_state: FeatureTree) -> None:
+        """Dry-run generated code against an isolated analytic kernel before live execution."""
+        from opencad.runtime import RuntimeContext
+
+        validation_ctx = RuntimeContext()
+        validation_ctx.tree = deepcopy(tree_state)
+        validation_ctx._sync_counters()
+        try:
+            self._execute_code_in_context(code, validation_ctx)
+        except Exception as exc:
+            raise GeneratedCodeValidationError(f"Generated code validation failed: {exc}") from exc
+
     @staticmethod
     def _execute_code_in_context(code: str, ctx: object) -> None:
         from opencad.runtime import reset_default_context, set_default_context
@@ -123,15 +152,23 @@ class OpenCadAgentService:
         finally:
             reset_default_context()
 
-    def _generate_code(self, request: ChatRequest) -> str:
-        model = os.environ.get("OPENCAD_LLM_MODEL")
+    def _generate_code(self, request: ChatRequest, *, user_message: str | None = None) -> str:
+        provider = request.llm_provider or os.environ.get("OPENCAD_LLM_PROVIDER")
+        model = request.llm_model or os.environ.get("OPENCAD_LLM_MODEL")
 
-        if model:
+        if not model:
+            raise AgentConfigurationError(
+                "Generate Code requires an LLM. Set OPENCAD_LLM_MODEL and, when needed, OPENCAD_LLM_PROVIDER."
+            )
+
+        try:
             return self.llm_client.generate_code(
+                provider=provider,
                 model=model,
                 system_prompt=build_code_generation_prompt(request.tree_state),
-                user_message=request.message,
+                user_message=user_message or request.message,
                 conversation_history=request.conversation_history,
                 reasoning=request.reasoning,
             )
-        return self.planner.generate_code(request.message)
+        except Exception as exc:
+            raise LlmGenerationError(f"LLM code generation failed: {exc}") from exc

--- a/backend/opencad_agent/tests/test_agent.py
+++ b/backend/opencad_agent/tests/test_agent.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 import pytest
 
+import opencad_agent.api as agent_api
 from opencad_agent.api import app
 from opencad_agent.generated_code import GeneratedCodePolicyError, validate_generated_code
 from opencad_agent.llm import LiteLlmProvider
 from opencad_agent.models import ChatRequest
-from opencad_agent.planner import OpenCadPlanner
+from opencad_agent.planner import UnsupportedPromptError
 from opencad_agent.prompting import build_code_generation_prompt, build_system_prompt
-from opencad_agent.service import OpenCadAgentService
+from opencad_agent.service import AgentConfigurationError, OpenCadAgentService
 from opencad_agent.tools import ToolRuntime
 from opencad_kernel.core.models import Success
 from opencad_kernel.operations.handlers import OpenCadKernel
@@ -48,26 +49,25 @@ def test_system_prompt_contains_required_instructions() -> None:
     assert "plan the full sequence before executing" in prompt
 
 
-def test_code_generation_prompt_contains_example_scripts() -> None:
+def test_code_generation_prompt_contains_api_guidance() -> None:
     prompt = build_code_generation_prompt(_seed_tree())
     assert "Return only valid Python code." in prompt
-    assert "examples/hardware_mounting_bracket.py" in prompt
     assert "from opencad import Part, Sketch" in prompt
     assert "Do not use filesystem" in prompt
+    assert "Valid repeated-feature composition example" in prompt
+    assert "Each Sketch variable may call exactly one" in prompt
 
 
-@pytest.mark.parametrize(
-    ("message", "expected"),
-    [
-        ("Generate a mounting bracket script", "Generated Mounting Bracket"),
-        ("Generate a PCB carrier script", "Generated PCB Carrier"),
-        ("Generate a simple part", "Generated Part"),
-    ],
-)
-def test_planner_generate_code_returns_example_style_scripts(message: str, expected: str) -> None:
-    code = OpenCadPlanner().generate_code(message)
-    assert "from opencad import Part, Sketch" in code
-    assert expected in code
+def test_deterministic_planner_rejects_unknown_requests() -> None:
+    service = OpenCadAgentService(live_kernel=False)
+    with pytest.raises(UnsupportedPromptError, match="Enable Generate Code"):
+        service.chat(
+            ChatRequest(
+                message="Build a cog",
+                tree_state=_seed_tree(),
+                generate_code=False,
+            )
+        )
 
 
 def test_mounting_bracket_prompt_generates_minimum_operations() -> None:
@@ -133,13 +133,26 @@ def test_chat_api_round_trip() -> None:
     assert body["new_tree_state"]["root_id"] == "root"
 
 
-def test_chat_api_can_return_generated_code() -> None:
+def test_chat_api_can_return_generated_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    generated_code = (
+        "from opencad import Part, Sketch\n"
+        'cog = Part(name="LLM Cog").cylinder(radius=10, height=3, name="Cog")\n'
+    )
+    fake_service = OpenCadAgentService(
+        live_kernel=False,
+        llm_client=LiteLlmProvider(
+            completion_func=lambda **_: {"choices": [{"message": {"content": generated_code}}]}
+        ),
+    )
+    monkeypatch.setattr(agent_api, "_service", fake_service)
     client = TestClient(app)
     payload = {
-        "message": "Generate a mounting bracket script",
+        "message": "Build a cog",
         "tree_state": _seed_tree().model_dump(),
         "conversation_history": [],
         "reasoning": False,
+        "llm_provider": "test",
+        "llm_model": "model",
         "generate_code": True,
     }
 
@@ -147,9 +160,8 @@ def test_chat_api_can_return_generated_code() -> None:
     assert response.status_code == 200
 
     body = response.json()
-    assert len(body["operations_executed"]) >= 1
-    assert body["generated_code"].startswith('"""Generated OpenCAD example')
-    assert "from opencad import Part, Sketch" in body["generated_code"]
+    assert len(body["operations_executed"]) == 1
+    assert body["generated_code"] == generated_code.strip()
     assert body["new_tree_state"]["root_id"] == "root"
     assert len(body["new_tree_state"]["nodes"]) > 1
 
@@ -169,8 +181,27 @@ def test_generated_code_policy_rejects_loops_before_execution() -> None:
         validate_generated_code("from opencad import Part, Sketch\nfor _ in range(10):\n    Part(name='Loop')\n")
 
 
+def test_generated_code_policy_rejects_disconnected_sketch_profiles() -> None:
+    code = """from opencad import Part, Sketch
+profile = Sketch(name="Invalid")
+profile.rect(10, 4)
+profile.circle(2)
+"""
+    with pytest.raises(GeneratedCodePolicyError, match="exactly one connected profile"):
+        validate_generated_code(code)
+
+
+def test_generated_code_policy_rejects_subtract_flag() -> None:
+    code = """from opencad import Part, Sketch
+profile = Sketch(name="Invalid").circle(2, subtract=True)
+"""
+    with pytest.raises(GeneratedCodePolicyError, match="subtract=True"):
+        validate_generated_code(code)
+
+
 def test_service_surfaces_generated_code_policy_failures() -> None:
     service = OpenCadAgentService(
+        live_kernel=False,
         llm_client=LiteLlmProvider(
             completion_func=lambda **_: {
                 "choices": [{"message": {"content": "from opencad import Part, Sketch\nopen('part.step', 'w')"}}]
@@ -178,7 +209,7 @@ def test_service_surfaces_generated_code_policy_failures() -> None:
         )
     )
 
-    with pytest.raises(RuntimeError, match="Generated code execution failed"):
+    with pytest.raises(RuntimeError, match="Generated code validation failed"):
         service.chat(
             ChatRequest(
                 message="Generate unsafe code",
@@ -260,7 +291,10 @@ Part(name="LLM Part")"""
             ]
         }
 
-    service = OpenCadAgentService(llm_client=LiteLlmProvider(completion_func=fake_completion))
+    service = OpenCadAgentService(
+        live_kernel=False,
+        llm_client=LiteLlmProvider(completion_func=fake_completion),
+    )
     response = service.chat(
         ChatRequest(
             message="Generate a PCB carrier script",
@@ -280,7 +314,22 @@ Part(name="LLM Part")"""
     assert isinstance(messages, list)
     system_messages = [message for message in messages if message["role"] == "system"]
     assert system_messages
-    assert any("examples/hardware_mounting_bracket.py" in message["content"] for message in system_messages)
+    assert any("Valid repeated-feature composition example" in message["content"] for message in system_messages)
+
+
+def test_generate_code_requires_configured_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENCAD_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENCAD_LLM_MODEL", raising=False)
+    service = OpenCadAgentService(live_kernel=False)
+
+    with pytest.raises(AgentConfigurationError, match="requires an LLM"):
+        service.chat(
+            ChatRequest(
+                message="Build a cog",
+                tree_state=_seed_tree(),
+                generate_code=True,
+            )
+        )
 
 
 def test_chat_request_requires_model_when_provider_is_set() -> None:

--- a/backend/opencad_kernel/operations/handlers.py
+++ b/backend/opencad_kernel/operations/handlers.py
@@ -230,13 +230,14 @@ class OpenCadKernel:
 
     def _run_boolean(self, op_name: BooleanOp, shape_a: ShapeData, shape_b: ShapeData) -> OperationResult:
         bbox_overlap = overlap_volume(shape_a.bbox, shape_b.bbox)
+        estimated_overlap = min(bbox_overlap, shape_a.volume, shape_b.volume)
 
         if op_name == "boolean_union":
-            result_volume = max(self.tolerance, shape_a.volume + shape_b.volume - bbox_overlap)
+            result_volume = shape_a.volume + shape_b.volume - estimated_overlap
             result_bbox = union_bbox(shape_a.bbox, shape_b.bbox)
 
         elif op_name == "boolean_cut":
-            result_volume = shape_a.volume - bbox_overlap
+            result_volume = shape_a.volume - estimated_overlap
             if result_volume <= self.tolerance:
                 return make_failure(
                     code=ErrorCode.ZERO_VOLUME,
@@ -247,7 +248,7 @@ class OpenCadKernel:
             result_bbox = shape_a.bbox
 
         else:  # boolean_intersection
-            result_volume = bbox_overlap
+            result_volume = estimated_overlap
             if result_volume <= self.tolerance:
                 return make_failure(
                     code=ErrorCode.BBOX_NEAR_TANGENT,

--- a/backend/opencad_kernel/tests/test_operations.py
+++ b/backend/opencad_kernel/tests/test_operations.py
@@ -88,6 +88,23 @@ def test_boolean_union_success(kernel: OpenCadKernel) -> None:
     assert result.shape.volume > 0.0
 
 
+def test_boolean_union_bounds_bbox_overlap_by_operand_volume(kernel: OpenCadKernel) -> None:
+    a_id, b_id = _make_two_boxes(kernel)
+    shape_a = kernel.store.get(a_id)
+    shape_b = kernel.store.get(b_id)
+    assert shape_a is not None and shape_b is not None
+    shape_a.volume = 0.2
+    shape_b.volume = 0.3
+    kernel.store.add(shape_a)
+    kernel.store.add(shape_b)
+
+    result = kernel.boolean_union(BooleanInput(shape_a_id=a_id, shape_b_id=b_id))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    assert result.shape.volume == pytest.approx(0.3)
+
+
 def test_boolean_union_no_overlap_fails(kernel: OpenCadKernel) -> None:
     a_id, b_id = _make_two_boxes(kernel)
     _translate_shape(kernel, b_id, dx=10.0, dy=0.0, dz=0.0)

--- a/opencad_viewport/src/api/client.test.ts
+++ b/opencad_viewport/src/api/client.test.ts
@@ -7,6 +7,7 @@ vi.mock("axios", () => ({
   default: {
     post: vi.fn(),
     get: vi.fn(),
+    isAxiosError: vi.fn(),
   },
 }));
 
@@ -52,6 +53,21 @@ describe("OpenCadApiClient routes", () => {
     expect(mockedAxios.get).toHaveBeenCalledWith("http://127.0.0.1:8003/kernel/shapes/shape-1/mesh", {
       params: { deflection: 0.2 },
     });
+  });
+
+  it("surfaces agent API error details", async () => {
+    const error = { response: { data: { detail: "Generate Code requires an LLM." } } };
+    mockedAxios.post.mockRejectedValue(error);
+    mockedAxios.isAxiosError.mockReturnValue(true);
+
+    const client = new OpenCadApiClient("http://127.0.0.1:8003", undefined, false, false);
+
+    await expect(client.sendChat({
+      message: "Build a cog",
+      tree_state: { nodes: {}, root_id: "root", active_branch: "main", revision: 0 },
+      conversation_history: [],
+      generate_code: true,
+    })).rejects.toThrow("Generate Code requires an LLM.");
   });
 
   it("uses custom kernel URL for streaming mesh events", () => {

--- a/opencad_viewport/src/api/client.ts
+++ b/opencad_viewport/src/api/client.ts
@@ -56,8 +56,18 @@ export class OpenCadApiClient {
       };
     }
 
-    const response = await axios.post<ChatResponsePayload>(`${this.baseUrl}/agent/chat`, request);
-    return response.data;
+    try {
+      const response = await axios.post<ChatResponsePayload>(`${this.baseUrl}/agent/chat`, request);
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const detail = error.response?.data?.detail;
+        if (typeof detail === "string") {
+          throw new Error(detail);
+        }
+      }
+      throw error;
+    }
   }
 
   async getTree(treeId: string): Promise<FeatureTreeView> {

--- a/opencad_viewport/src/types.ts
+++ b/opencad_viewport/src/types.ts
@@ -127,6 +127,8 @@ export interface ChatRequestPayload {
   tree_state: FeatureTreeView;
   conversation_history: ChatHistoryItem[];
   reasoning?: boolean;
+  llm_provider?: string;
+  llm_model?: string;
   generate_code?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- remove hardcoded and generic geometry fallbacks from code generation
- use the configured LLM provider and model for generated CAD code
- return clear errors when LLM generation is disabled, unavailable, or invalid
- validate generated sketches and dry-run code before live kernel execution
- improve cog and repeated-feature guidance and repair invalid output once
- surface backend error details in the viewport
- bound analytic boolean overlap estimates by operand volume
- add local configuration guidance and regression coverage

## Verification

- 48 focused agent and kernel tests passed
- 4 viewport API client tests passed
- viewport production build passed