### PR TITLE
Separate geometry backend implementations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,15 @@
 # Architecture
 
+## Geometry Backend Boundary
+
+- `opencad_kernel.operations.handlers.OpenCadKernel` is the stable coordinator used by the registry and public APIs.
+- Geometry is implemented behind `KernelBackend`; the coordinator contains no geometry algorithms.
+- `opencad_kernel.core.occt_backend.OcctBackend` owns production B-rep construction, topology, file I/O, and tessellation.
+- `opencad_kernel.core.analytic_backend.AnalyticBackend` owns the metadata-only approximation used by lightweight and isolated tests.
+- Assembly mates and the shared topology selector stay in the coordinator because they are application-level behavior rather than geometry-engine behavior.
+- Every operation-log entry records the concrete backend class that executed it, allowing snapshots and diagnostics to distinguish analytic results from OCCT results.
+- Face-by-face mesh streaming is tracked separately through the optional `StreamingMeshBackend` capability.
+
 ## 4 – Viewport Application (`opencad_viewport`)
 
 ### Frontend Components

--- a/backend/opencad/runtime.py
+++ b/backend/opencad/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from opencad_kernel.core.backend import KernelBackend
 from opencad_kernel.operations.handlers import OpenCadKernel
 from opencad_kernel.operations.registry import OperationRegistry
 from opencad.kernel_adapter import execute_feature_node, registry_result_to_dict
@@ -18,9 +19,15 @@ if TYPE_CHECKING:
 class RuntimeContext:
     """Single-process OpenCAD runtime for headless/fluent usage."""
 
-    def __init__(self, *, id_strategy: str = "readable", kernel_call_fn: KernelCallFn | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        id_strategy: str = "readable",
+        kernel_call_fn: KernelCallFn | None = None,
+        backend: KernelBackend | None = None,
+    ) -> None:
         self._external_kernel_call = kernel_call_fn
-        self.kernel = OpenCadKernel(id_strategy=id_strategy)
+        self.kernel = OpenCadKernel(id_strategy=id_strategy, backend=backend)
         self.registry = OperationRegistry(self.kernel)
         self.tree = FeatureTree(root_id="root")
         self.last_feature_id: str | None = None

--- a/backend/opencad_kernel/api.py
+++ b/backend/opencad_kernel/api.py
@@ -18,6 +18,7 @@ from starlette.background import BackgroundTask
 from opencad.api_app import create_api_app
 from opencad.version import __version__
 from opencad_kernel.core.errors import Failure
+from opencad_kernel.core.backend import StreamingMeshBackend
 from opencad_kernel.core.models import MeshData, OperationResult, Success
 from opencad_kernel.core.snapshot import SnapshotV1
 from opencad_kernel.operations.handlers import OpenCadKernel
@@ -309,10 +310,10 @@ async def stream_mesh(
 ) -> StreamingResponse:
     """Stream tessellated mesh face-by-face as Server-Sent Events."""
     backend = _KERNEL.backend
-    if backend is None:
+    if not isinstance(backend, StreamingMeshBackend):
         raise HTTPException(
             status_code=501,
-            detail="Streaming tessellation requires an OCCT backend.",
+            detail="Streaming tessellation requires a face-streaming backend.",
         )
 
     # Verify shape exists before starting the stream
@@ -321,12 +322,6 @@ async def stream_mesh(
 
     async def _event_generator():
         try:
-            from opencad_kernel.core.occt_backend import OcctBackend
-
-            if not isinstance(backend, OcctBackend):
-                yield f"data: {json.dumps({'error': 'Backend does not support face streaming'})}\n\n"
-                return
-
             total = backend.count_faces(shape_id)
             for face_idx in range(total):
                 mesh, _ = backend.tessellate_face(shape_id, face_idx, deflection)

--- a/backend/opencad_kernel/core/__init__.py
+++ b/backend/opencad_kernel/core/__init__.py
@@ -1,4 +1,5 @@
-from .backend import KernelBackend
+from .analytic_backend import AnalyticBackend
+from .backend import KernelBackend, StreamingMeshBackend
 from .errors import ErrorCode, Failure, make_failure
 from .models import (
     BoundingBox,
@@ -14,6 +15,7 @@ from .store import ShapeStore
 
 __all__ = [
     "BoundingBox",
+    "AnalyticBackend",
     "ErrorCode",
     "Failure",
     "KernelBackend",
@@ -24,6 +26,7 @@ __all__ = [
     "SubshapeKind",
     "SubshapeRef",
     "Success",
+    "StreamingMeshBackend",
     "TopologyMap",
     "make_failure",
 ]

--- a/backend/opencad_kernel/core/analytic_backend.py
+++ b/backend/opencad_kernel/core/analytic_backend.py
@@ -1,0 +1,964 @@
+from __future__ import annotations
+
+import json
+import math
+import struct
+from math import pow
+from pathlib import Path
+from typing import Any, Literal
+
+from opencad_kernel.core.checks import check_bbox_overlap, check_manifold, check_nonzero_volume
+from opencad_kernel.core.errors import ErrorCode, make_failure
+from opencad_kernel.core.geometry import (
+    box_bbox,
+    box_volume,
+    cylinder_bbox,
+    cylinder_volume,
+    overlap_bbox,
+    overlap_volume,
+    sphere_bbox,
+    sphere_volume,
+    union_bbox,
+)
+from opencad_kernel.core.models import (
+    BoundingBox,
+    MeshData,
+    OperationResult,
+    ShapeData,
+    Success,
+    TopologyMap,
+)
+from opencad_kernel.core.store import IdStrategy, ShapeStore
+from opencad_kernel.core.topology import build_synthetic_topology
+from opencad_kernel.operations.schemas import (
+    BooleanInput,
+    ChamferEdgesInput,
+    CircularPatternInput,
+    CreateBoxInput,
+    CreateConeInput,
+    CreateCylinderInput,
+    CreateSketchInput,
+    CreateSphereInput,
+    CreateTorusInput,
+    DraftInput,
+    ExportStlInput,
+    ExportStepInput,
+    ExtrudeInput,
+    FilletEdgesInput,
+    ImportStepInput,
+    ImportStlInput,
+    LinearPatternInput,
+    LoftInput,
+    MirrorInput,
+    OffsetShapeInput,
+    RevolveInput,
+    ShellInput,
+    SweepInput,
+)
+
+BooleanOp = Literal["boolean_union", "boolean_cut", "boolean_intersection"]
+
+
+def _read_stl_vertices(filepath: Path) -> list[tuple[float, float, float]]:
+    data = filepath.read_bytes()
+    vertices: list[tuple[float, float, float]] = []
+
+    if data.lstrip().lower().startswith(b"solid"):
+        for line in data.decode("utf-8", errors="ignore").splitlines():
+            fields = line.strip().split()
+            if len(fields) == 4 and fields[0].lower() == "vertex":
+                vertices.append((float(fields[1]), float(fields[2]), float(fields[3])))
+        if vertices:
+            return vertices
+
+    if len(data) < 84:
+        raise ValueError("STL file is too short.")
+    triangle_count = struct.unpack_from("<I", data, 80)[0]
+    expected_size = 84 + triangle_count * 50
+    if len(data) < expected_size:
+        raise ValueError("Binary STL triangle data is truncated.")
+    for triangle_index in range(triangle_count):
+        offset = 84 + triangle_index * 50 + 12
+        coordinates = struct.unpack_from("<9f", data, offset)
+        vertices.extend(
+            (coordinates[index], coordinates[index + 1], coordinates[index + 2])
+            for index in range(0, 9, 3)
+        )
+    return vertices
+
+
+def _triangle_normal(
+    a: tuple[float, float, float],
+    b: tuple[float, float, float],
+    c: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    ux, uy, uz = b[0] - a[0], b[1] - a[1], b[2] - a[2]
+    vx, vy, vz = c[0] - a[0], c[1] - a[1], c[2] - a[2]
+    nx, ny, nz = uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx
+    length = math.sqrt(nx * nx + ny * ny + nz * nz)
+    if length <= 1e-12:
+        return (0.0, 0.0, 0.0)
+    return (nx / length, ny / length, nz / length)
+
+
+def _bbox_stl(shape: ShapeData) -> str:
+    box = shape.bbox
+    points = [
+        (box.min_x, box.min_y, box.min_z),
+        (box.max_x, box.min_y, box.min_z),
+        (box.max_x, box.max_y, box.min_z),
+        (box.min_x, box.max_y, box.min_z),
+        (box.min_x, box.min_y, box.max_z),
+        (box.max_x, box.min_y, box.max_z),
+        (box.max_x, box.max_y, box.max_z),
+        (box.min_x, box.max_y, box.max_z),
+    ]
+    triangles = [
+        (0, 2, 1), (0, 3, 2), (4, 5, 6), (4, 6, 7),
+        (0, 1, 5), (0, 5, 4), (1, 2, 6), (1, 6, 5),
+        (2, 3, 7), (2, 7, 6), (3, 0, 4), (3, 4, 7),
+    ]
+    lines = ["solid opencad"]
+    for first, second, third in triangles:
+        a, b, c = points[first], points[second], points[third]
+        normal = _triangle_normal(a, b, c)
+        lines.append(f"  facet normal {normal[0]} {normal[1]} {normal[2]}")
+        lines.append("    outer loop")
+        for vertex in (a, b, c):
+            lines.append(f"      vertex {vertex[0]} {vertex[1]} {vertex[2]}")
+        lines.extend(("    endloop", "  endfacet"))
+    lines.append("endsolid opencad")
+    return "\n".join(lines) + "\n"
+
+
+class AnalyticBackend:
+    """Lightweight metadata-only geometry backend.
+
+    This backend intentionally approximates geometry with bounding boxes and
+    analytic measurements. It exists for tests and environments where OCCT is
+    unavailable; production geometry should use :class:`OcctBackend`.
+    """
+
+    def __init__(
+        self,
+        tolerance: float = 1e-6,
+        allow_partial_boolean: bool = False,
+        id_strategy: IdStrategy = "uuid",
+    ) -> None:
+        self.tolerance = tolerance
+        self.allow_partial_boolean = allow_partial_boolean
+        self.store = ShapeStore(id_strategy=id_strategy)
+
+    def _invalid_input(self, message: str) -> OperationResult:
+        return make_failure(
+            code=ErrorCode.INVALID_INPUT,
+            message=message,
+            suggestion="Review numeric inputs and try again.",
+            failed_check="input_validation",
+        )
+
+    def _shape_not_found(self, shape_id: str) -> OperationResult:
+        return make_failure(
+            code=ErrorCode.SHAPE_NOT_FOUND,
+            message=f"Shape '{shape_id}' was not found.",
+            suggestion="Use an existing shape_id from a previous successful operation.",
+            failed_check="shape_lookup",
+        )
+
+    def _success(self, shape: ShapeData, operation: str, **metadata: object) -> Success:
+        self.store.add(shape)
+        return Success(shape_id=shape.id, shape=shape, metadata={"operation": operation, **metadata})
+
+    def _make_shape(
+        self,
+        kind: str,
+        bbox: BoundingBox,
+        volume: float,
+        parameters: dict[str, object],
+        manifold: bool = True,
+        edge_count: int = 0,
+        face_count: int = 0,
+        source_ids: list[str] | None = None,
+    ) -> ShapeData:
+        shape_id = self.store.new_id(kind)
+        edges = [f"{shape_id}:edge:{idx}" for idx in range(edge_count)]
+        faces = [f"{shape_id}:face:{idx}" for idx in range(face_count)]
+        return ShapeData(
+            id=shape_id,
+            kind=kind,
+            parameters=parameters,
+            bbox=bbox,
+            volume=volume,
+            manifold=manifold,
+            edge_ids=edges,
+            face_ids=faces,
+            source_ids=source_ids or [],
+        )
+
+    def create_box(self, payload: CreateBoxInput) -> OperationResult:
+        if payload.length <= self.tolerance or payload.width <= self.tolerance or payload.height <= self.tolerance:
+            return self._invalid_input("Box dimensions must be greater than tolerance.")
+
+        shape = self._make_shape(
+            kind="box",
+            bbox=box_bbox(payload.length, payload.width, payload.height),
+            volume=box_volume(payload.length, payload.width, payload.height),
+            parameters=payload.model_dump(),
+            edge_count=12,
+            face_count=6,
+        )
+        return self._success(shape, "create_box")
+
+    def create_cylinder(self, payload: CreateCylinderInput) -> OperationResult:
+        if payload.radius <= self.tolerance or payload.height <= self.tolerance:
+            return self._invalid_input("Cylinder radius and height must be greater than tolerance.")
+
+        shape = self._make_shape(
+            kind="cylinder",
+            bbox=cylinder_bbox(payload.radius, payload.height),
+            volume=cylinder_volume(payload.radius, payload.height),
+            parameters=payload.model_dump(),
+            edge_count=3,
+            face_count=3,
+        )
+        return self._success(shape, "create_cylinder")
+
+    def create_sphere(self, payload: CreateSphereInput) -> OperationResult:
+        if payload.radius <= self.tolerance:
+            return self._invalid_input("Sphere radius must be greater than tolerance.")
+
+        shape = self._make_shape(
+            kind="sphere",
+            bbox=sphere_bbox(payload.radius),
+            volume=sphere_volume(payload.radius),
+            parameters=payload.model_dump(),
+            edge_count=1,
+            face_count=1,
+        )
+        return self._success(shape, "create_sphere")
+
+    def _fetch_shape_pair(self, payload: BooleanInput) -> tuple[ShapeData, ShapeData] | OperationResult:
+        shape_a = self.store.get(payload.shape_a_id)
+        if not shape_a:
+            return self._shape_not_found(payload.shape_a_id)
+
+        shape_b = self.store.get(payload.shape_b_id)
+        if not shape_b:
+            return self._shape_not_found(payload.shape_b_id)
+
+        return shape_a, shape_b
+
+    def _preflight_boolean(
+        self,
+        op_name: BooleanOp,
+        shape_a: ShapeData,
+        shape_b: ShapeData,
+    ) -> OperationResult | None:
+        volume_a = check_nonzero_volume(shape_a, self.tolerance)
+        if volume_a:
+            return volume_a
+
+        volume_b = check_nonzero_volume(shape_b, self.tolerance)
+        if volume_b:
+            return volume_b
+
+        manifold_a = check_manifold(shape_a)
+        if manifold_a:
+            return manifold_a
+
+        manifold_b = check_manifold(shape_b)
+        if manifold_b:
+            return manifold_b
+
+        if op_name in {"boolean_union", "boolean_intersection"}:
+            overlap = check_bbox_overlap(shape_a, shape_b, self.tolerance)
+            if overlap:
+                return overlap
+
+        return None
+
+    def _run_boolean(self, op_name: BooleanOp, shape_a: ShapeData, shape_b: ShapeData) -> OperationResult:
+        bbox_overlap = overlap_volume(shape_a.bbox, shape_b.bbox)
+        estimated_overlap = min(bbox_overlap, shape_a.volume, shape_b.volume)
+
+        if op_name == "boolean_union":
+            result_volume = shape_a.volume + shape_b.volume - estimated_overlap
+            result_bbox = union_bbox(shape_a.bbox, shape_b.bbox)
+
+        elif op_name == "boolean_cut":
+            result_volume = shape_a.volume - estimated_overlap
+            if result_volume <= self.tolerance:
+                return make_failure(
+                    code=ErrorCode.ZERO_VOLUME,
+                    message="Boolean cut removed all material from the base shape.",
+                    suggestion="Reduce overlap or choose a different cutting shape.",
+                    failed_check="boolean_result_volume",
+                )
+            result_bbox = shape_a.bbox
+
+        else:  # boolean_intersection
+            result_volume = estimated_overlap
+            if result_volume <= self.tolerance:
+                return make_failure(
+                    code=ErrorCode.BBOX_NEAR_TANGENT,
+                    message="Intersection produced near-zero volume.",
+                    suggestion="Increase overlap between shapes before intersection.",
+                    failed_check="boolean_result_volume",
+                )
+            result_bbox = overlap_bbox(shape_a.bbox, shape_b.bbox)
+
+        result = self._make_shape(
+            kind=op_name,
+            bbox=result_bbox,
+            volume=result_volume,
+            parameters={"shape_a_id": shape_a.id, "shape_b_id": shape_b.id},
+            edge_count=max(1, len(shape_a.edge_ids) + len(shape_b.edge_ids)),
+            source_ids=[shape_a.id, shape_b.id],
+        )
+        return self._success(result, op_name, preflight="passed")
+
+    def _boolean(self, op_name: BooleanOp, payload: BooleanInput) -> OperationResult:
+        pair = self._fetch_shape_pair(payload)
+        if not isinstance(pair, tuple):
+            return pair
+
+        shape_a, shape_b = pair
+        preflight = self._preflight_boolean(op_name, shape_a, shape_b)
+        if preflight is not None:
+            return preflight
+
+        try:
+            return self._run_boolean(op_name, shape_a, shape_b)
+        except Exception as exc:  # pragma: no cover
+            return make_failure(
+                code=ErrorCode.BOOLEAN_KERNEL_ERROR,
+                message=f"Boolean operation failed: {exc}",
+                suggestion="Inspect input geometry and retry with cleaned shapes.",
+                failed_check="kernel_execution",
+            )
+
+    def boolean_union(self, payload: BooleanInput) -> OperationResult:
+        return self._boolean("boolean_union", payload)
+
+    def boolean_cut(self, payload: BooleanInput) -> OperationResult:
+        return self._boolean("boolean_cut", payload)
+
+    def boolean_intersection(self, payload: BooleanInput) -> OperationResult:
+        return self._boolean("boolean_intersection", payload)
+
+    def fillet_edges(self, payload: FilletEdgesInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+
+        if not payload.edge_ids:
+            return self._invalid_input("At least one edge_id is required for fillet.")
+        if payload.radius <= self.tolerance:
+            return self._invalid_input("Fillet radius must be greater than tolerance.")
+
+        dx = shape.bbox.max_x - shape.bbox.min_x
+        dy = shape.bbox.max_y - shape.bbox.min_y
+        dz = shape.bbox.max_z - shape.bbox.min_z
+        max_radius = max(self.tolerance, min(dx, dy, dz) / 2.0)
+        if payload.radius >= max_radius:
+            return make_failure(
+                code=ErrorCode.FILLET_RADIUS_TOO_LARGE,
+                message=f"Fillet radius {payload.radius} exceeds max allowed {max_radius:.6f}.",
+                suggestion="Reduce fillet radius or increase base feature size.",
+                failed_check="fillet_radius",
+            )
+
+        reduction = min(0.5, 0.02 * len(payload.edge_ids))
+        shape_out = self._make_shape(
+            kind="fillet",
+            bbox=shape.bbox,
+            volume=max(self.tolerance, shape.volume * (1.0 - reduction)),
+            parameters={"shape_id": payload.shape_id, "edge_ids": payload.edge_ids, "radius": payload.radius},
+            edge_count=max(1, len(shape.edge_ids)),
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "fillet_edges")
+
+    def offset_shape(self, payload: OffsetShapeInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+
+        dx = shape.bbox.max_x - shape.bbox.min_x
+        dy = shape.bbox.max_y - shape.bbox.min_y
+        dz = shape.bbox.max_z - shape.bbox.min_z
+        if payload.distance < 0 and (dx + (2 * payload.distance) <= self.tolerance or dy + (2 * payload.distance) <= self.tolerance or dz + (2 * payload.distance) <= self.tolerance):
+            return make_failure(
+                code=ErrorCode.OFFSET_COLLAPSE,
+                message="Negative offset collapses the shape.",
+                suggestion="Use a smaller negative offset or a positive offset.",
+                failed_check="offset_validity",
+            )
+
+        out_bbox = BoundingBox(
+            min_x=shape.bbox.min_x - payload.distance,
+            min_y=shape.bbox.min_y - payload.distance,
+            min_z=shape.bbox.min_z - payload.distance,
+            max_x=shape.bbox.max_x + payload.distance,
+            max_y=shape.bbox.max_y + payload.distance,
+            max_z=shape.bbox.max_z + payload.distance,
+        )
+
+        out_shape = self._make_shape(
+            kind="offset",
+            bbox=out_bbox,
+            volume=max(self.tolerance, out_bbox.volume()),
+            parameters={"shape_id": payload.shape_id, "distance": payload.distance},
+            edge_count=max(1, len(shape.edge_ids)),
+            source_ids=[shape.id],
+        )
+        return self._success(out_shape, "offset_shape")
+
+    def import_step(self, payload: ImportStepInput) -> OperationResult:
+        filepath = Path(payload.filepath)
+        if filepath.suffix.lower() not in {".step", ".stp"}:
+            return make_failure(
+                code=ErrorCode.UNSUPPORTED_STEP,
+                message="Only .step and .stp files are supported.",
+                suggestion="Convert the source file to STEP format.",
+                failed_check="step_extension",
+            )
+
+        try:
+            text = filepath.read_text(encoding="utf-8")
+        except OSError as exc:
+            return make_failure(
+                code=ErrorCode.IO_ERROR,
+                message=f"Failed to read STEP file: {exc}",
+                suggestion="Verify file path and read permissions.",
+                failed_check="step_io",
+            )
+
+        parsed: dict[str, object] = {}
+        lines = text.splitlines()
+        if lines and lines[0].strip() == "OPENCAD-MOCK" and len(lines) > 1:
+            try:
+                parsed = json.loads(lines[1])
+            except json.JSONDecodeError:
+                parsed = {}
+
+        if "bbox" in parsed and isinstance(parsed["bbox"], dict):
+            bbox = BoundingBox.model_validate(parsed["bbox"])
+            volume = float(parsed.get("volume", bbox.volume()))
+        else:
+            approx_volume = max(1.0, len(text) * 1e-3)
+            side = pow(approx_volume, 1.0 / 3.0)
+            bbox = BoundingBox(min_x=0.0, min_y=0.0, min_z=0.0, max_x=side, max_y=side, max_z=side)
+            volume = approx_volume
+
+        shape = self._make_shape(
+            kind="imported_step",
+            bbox=bbox,
+            volume=volume,
+            parameters={"filepath": payload.filepath},
+            edge_count=12,
+        )
+        return self._success(shape, "import_step", imported_from=payload.filepath)
+
+    def export_step(self, payload: ExportStepInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+
+        filepath = Path(payload.filepath)
+        payload_data = {
+            "shape_id": shape.id,
+            "kind": shape.kind,
+            "volume": shape.volume,
+            "bbox": shape.bbox.model_dump(),
+            "parameters": shape.parameters,
+        }
+        try:
+            filepath.write_text(f"OPENCAD-MOCK\n{json.dumps(payload_data)}\n", encoding="utf-8")
+        except OSError as exc:
+            return make_failure(
+                code=ErrorCode.IO_ERROR,
+                message=f"Failed to write STEP file: {exc}",
+                suggestion="Verify destination directory permissions.",
+                failed_check="step_io",
+            )
+
+        return Success(shape_id=shape.id, shape=None, metadata={"operation": "export_step", "filepath": payload.filepath})
+
+    def import_stl(self, payload: ImportStlInput) -> OperationResult:
+        filepath = Path(payload.filepath)
+        if filepath.suffix.lower() != ".stl":
+            return make_failure(
+                code=ErrorCode.UNSUPPORTED_FILE_FORMAT,
+                message="STL import requires a .stl file.",
+                suggestion="Choose an STL file.",
+                failed_check="stl_extension",
+            )
+        try:
+            vertices = _read_stl_vertices(filepath)
+        except (OSError, ValueError, struct.error) as exc:
+            return make_failure(
+                code=ErrorCode.IO_ERROR,
+                message=f"Failed to read STL file: {exc}",
+                suggestion="Verify that the file is a valid ASCII or binary STL.",
+                failed_check="stl_io",
+            )
+        if len(vertices) < 3:
+            return make_failure(
+                code=ErrorCode.IO_ERROR,
+                message="STL file contains no triangles.",
+                suggestion="Choose a non-empty STL file.",
+                failed_check="stl_geometry",
+            )
+        xs, ys, zs = zip(*vertices)
+        bbox = BoundingBox(
+            min_x=min(xs), min_y=min(ys), min_z=min(zs),
+            max_x=max(xs), max_y=max(ys), max_z=max(zs),
+        )
+        shape = self._make_shape(
+            kind="imported_stl",
+            bbox=bbox,
+            volume=max(self.tolerance, bbox.volume()),
+            parameters={"filepath": payload.filepath},
+            edge_count=len(vertices),
+            face_count=len(vertices) // 3,
+        )
+        return self._success(shape, "import_stl", imported_from=payload.filepath)
+
+    def export_stl(self, payload: ExportStlInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        filepath = Path(payload.filepath)
+        if filepath.suffix.lower() != ".stl":
+            return make_failure(
+                code=ErrorCode.UNSUPPORTED_FILE_FORMAT,
+                message="STL export requires a .stl destination.",
+                suggestion="Use a filename ending in .stl.",
+                failed_check="stl_extension",
+            )
+        try:
+            filepath.write_text(_bbox_stl(shape), encoding="utf-8")
+        except OSError as exc:
+            return make_failure(
+                code=ErrorCode.IO_ERROR,
+                message=f"Failed to write STL file: {exc}",
+                suggestion="Verify destination directory permissions.",
+                failed_check="stl_io",
+            )
+        return Success(shape_id=shape.id, shape=None, metadata={"operation": "export_stl", "filepath": payload.filepath})
+
+    # ── Tessellation (delegates to backend) ─────────────────────────
+
+    def tessellate(self, shape_id: str, deflection: float = 0.1) -> MeshData:
+        """Tessellate the shape identified by *shape_id*.
+
+        Requires an OCCT (or other tessellation-capable) backend.
+        The analytic fallback kernel cannot produce mesh data.
+        """
+        raise NotImplementedError(
+            "Tessellation requires an OCCT backend.  "
+            "Start the kernel with OPENCAD_KERNEL_BACKEND=occt."
+        )
+
+    def get_native_shape(self, shape_id: str) -> Any:
+        return None
+
+    # ── Additional primitives ───────────────────────────────────────
+
+    def create_cone(self, payload: CreateConeInput) -> OperationResult:
+        if payload.height <= self.tolerance:
+            return self._invalid_input("Cone height must be greater than tolerance.")
+        if payload.radius1 <= self.tolerance and payload.radius2 <= self.tolerance:
+            return self._invalid_input("At least one cone radius must be greater than tolerance.")
+
+        r1, r2, h = payload.radius1, payload.radius2, payload.height
+        r_max = max(r1, r2)
+        vol = (math.pi * h / 3.0) * (r1 ** 2 + r2 ** 2 + r1 * r2)
+        bbox = BoundingBox(min_x=-r_max, min_y=-r_max, min_z=0.0, max_x=r_max, max_y=r_max, max_z=h)
+        shape = self._make_shape("cone", bbox, vol, payload.model_dump(), edge_count=3, face_count=3)
+        return self._success(shape, "create_cone")
+
+    def create_torus(self, payload: CreateTorusInput) -> OperationResult:
+        if payload.major_radius <= self.tolerance or payload.minor_radius <= self.tolerance:
+            return self._invalid_input("Torus radii must be greater than tolerance.")
+        if payload.minor_radius >= payload.major_radius:
+            return self._invalid_input("Minor radius must be less than major radius.")
+
+        R, r = payload.major_radius, payload.minor_radius
+        vol = 2 * math.pi ** 2 * R * r ** 2
+        outer = R + r
+        bbox = BoundingBox(min_x=-outer, min_y=-outer, min_z=-r, max_x=outer, max_y=outer, max_z=r)
+        shape = self._make_shape("torus", bbox, vol, payload.model_dump(), edge_count=2, face_count=1)
+        return self._success(shape, "create_torus")
+
+    # ── Chamfer ─────────────────────────────────────────────────────
+
+    def chamfer_edges(self, payload: ChamferEdgesInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        if not payload.edge_ids:
+            return self._invalid_input("At least one edge_id is required for chamfer.")
+        if payload.distance <= self.tolerance:
+            return self._invalid_input("Chamfer distance must be greater than tolerance.")
+
+        reduction = min(0.5, 0.015 * len(payload.edge_ids))
+        shape_out = self._make_shape(
+            kind="chamfer",
+            bbox=shape.bbox,
+            volume=max(self.tolerance, shape.volume * (1.0 - reduction)),
+            parameters={"shape_id": payload.shape_id, "edge_ids": payload.edge_ids, "distance": payload.distance},
+            edge_count=max(1, len(shape.edge_ids) + len(payload.edge_ids)),
+            face_count=max(1, len(shape.face_ids) + len(payload.edge_ids)),
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "chamfer_edges")
+
+    # ── Shell ───────────────────────────────────────────────────────
+
+    def shell(self, payload: ShellInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        if payload.thickness <= self.tolerance:
+            return self._invalid_input("Shell thickness must be greater than tolerance.")
+
+        # Heuristic: shell removes volume proportional to thickness
+        dx = shape.bbox.max_x - shape.bbox.min_x
+        dy = shape.bbox.max_y - shape.bbox.min_y
+        dz = shape.bbox.max_z - shape.bbox.min_z
+        inner_vol = max(0.0, (dx - 2 * payload.thickness) * (dy - 2 * payload.thickness) * (dz - 2 * payload.thickness))
+        if inner_vol <= self.tolerance:
+            return make_failure(
+                code=ErrorCode.SHELL_FAILURE,
+                message="Shell thickness too large — would consume entire solid.",
+                suggestion="Reduce shell thickness.",
+                failed_check="shell_validity",
+            )
+
+        shell_vol = shape.volume - inner_vol
+        shape_out = self._make_shape(
+            kind="shell",
+            bbox=shape.bbox,
+            volume=max(self.tolerance, shell_vol),
+            parameters={"shape_id": payload.shape_id, "face_ids": payload.face_ids, "thickness": payload.thickness},
+            edge_count=max(1, len(shape.edge_ids) * 2),
+            face_count=max(1, len(shape.face_ids) * 2 - len(payload.face_ids)),
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "shell")
+
+    # ── Draft ───────────────────────────────────────────────────────
+
+    def draft(self, payload: DraftInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        if not payload.face_ids:
+            return self._invalid_input("At least one face_id is required for draft.")
+        if abs(payload.angle) <= self.tolerance:
+            return self._invalid_input("Draft angle must be non-zero.")
+        if abs(payload.angle) >= 90.0:
+            return self._invalid_input("Draft angle must be less than 90 degrees.")
+
+        # Draft slightly expands bbox
+        tan_a = math.tan(math.radians(abs(payload.angle)))
+        expand = tan_a * (shape.bbox.max_z - shape.bbox.min_z) * 0.5
+        draft_bbox = BoundingBox(
+            min_x=shape.bbox.min_x - expand, min_y=shape.bbox.min_y - expand, min_z=shape.bbox.min_z,
+            max_x=shape.bbox.max_x + expand, max_y=shape.bbox.max_y + expand, max_z=shape.bbox.max_z,
+        )
+        shape_out = self._make_shape(
+            kind="draft",
+            bbox=draft_bbox,
+            volume=max(self.tolerance, shape.volume * (1.0 + 0.01 * abs(payload.angle))),
+            parameters=payload.model_dump(),
+            edge_count=max(1, len(shape.edge_ids)),
+            face_count=max(1, len(shape.face_ids)),
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "draft")
+
+    # ── Sketch operations ───────────────────────────────────────────
+
+    def create_sketch(self, payload: CreateSketchInput) -> OperationResult:
+        if not payload.segments:
+            return self._invalid_input("Sketch must contain at least one segment.")
+
+        # Compute bounding box of 2D segments
+        xs: list[float] = []
+        ys: list[float] = []
+        for seg in payload.segments:
+            if seg.start:
+                xs.append(seg.start[0]); ys.append(seg.start[1])
+            if seg.end:
+                xs.append(seg.end[0]); ys.append(seg.end[1])
+            if seg.center:
+                r = seg.radius or 0.0
+                xs.extend([seg.center[0] - r, seg.center[0] + r])
+                ys.extend([seg.center[1] - r, seg.center[1] + r])
+
+        if not xs:
+            return self._invalid_input("Sketch segments have no defined points.")
+
+        ox, oy, oz = payload.origin
+        # Map 2D bbox to 3D based on plane
+        min2x, max2x = min(xs), max(xs)
+        min2y, max2y = min(ys), max(ys)
+        if payload.plane == "XZ":
+            bbox = BoundingBox(min_x=ox + min2x, min_y=oy, min_z=oz + min2y,
+                               max_x=ox + max2x, max_y=oy, max_z=oz + max2y)
+        elif payload.plane == "YZ":
+            bbox = BoundingBox(min_x=ox, min_y=oy + min2x, min_z=oz + min2y,
+                               max_x=ox, max_y=oy + max2x, max_z=oz + max2y)
+        else:  # XY
+            bbox = BoundingBox(min_x=ox + min2x, min_y=oy + min2y, min_z=oz,
+                               max_x=ox + max2x, max_y=oy + max2y, max_z=oz)
+
+        shape = self._make_shape(
+            kind="sketch",
+            bbox=bbox,
+            volume=0.0,
+            parameters=payload.model_dump(),
+            manifold=False,
+            edge_count=len(payload.segments),
+            face_count=0,
+        )
+        return self._success(shape, "create_sketch")
+
+    def extrude(self, payload: ExtrudeInput) -> OperationResult:
+        sketch = self.store.get(payload.sketch_id)
+        if not sketch:
+            return self._shape_not_found(payload.sketch_id)
+        if abs(payload.distance) <= self.tolerance:
+            return self._invalid_input("Extrude distance must be non-zero.")
+
+        d = abs(payload.distance)
+        if payload.both:
+            d *= 2
+        sb = sketch.bbox
+        # Extrude along Z (most common; sketch plane defines this)
+        bbox = BoundingBox(
+            min_x=sb.min_x, min_y=sb.min_y,
+            min_z=sb.min_z - (d / 2 if payload.both else 0.0),
+            max_x=sb.max_x, max_y=sb.max_y,
+            max_z=sb.max_z + (d / 2 if payload.both else d),
+        )
+        area_2d = max(self.tolerance, (sb.max_x - sb.min_x) * (sb.max_y - sb.min_y))
+        vol = area_2d * d
+        shape = self._make_shape(
+            kind="extrude",
+            bbox=bbox,
+            volume=vol,
+            parameters=payload.model_dump(),
+            edge_count=12,
+            face_count=6,
+            source_ids=[sketch.id],
+        )
+        return self._success(shape, "extrude")
+
+    # ── Revolve ─────────────────────────────────────────────────────
+
+    def revolve(self, payload: RevolveInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        if abs(payload.angle) <= self.tolerance:
+            return self._invalid_input("Revolve angle must be non-zero.")
+
+        # Estimate: revolve the profile's bbox extent around the axis
+        sb = shape.bbox
+        max_extent = max(
+            abs(sb.max_x - payload.axis_origin[0]),
+            abs(sb.min_x - payload.axis_origin[0]),
+            abs(sb.max_y - payload.axis_origin[1]),
+            abs(sb.min_y - payload.axis_origin[1]),
+        )
+        h = sb.max_z - sb.min_z
+        frac = min(abs(payload.angle), 360.0) / 360.0
+        vol = math.pi * max_extent ** 2 * max(h, self.tolerance) * frac
+        bbox = BoundingBox(
+            min_x=-max_extent, min_y=-max_extent, min_z=sb.min_z,
+            max_x=max_extent, max_y=max_extent, max_z=sb.max_z,
+        )
+        shape_out = self._make_shape(
+            kind="revolve",
+            bbox=bbox,
+            volume=vol,
+            parameters=payload.model_dump(),
+            edge_count=4,
+            face_count=4,
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "revolve")
+
+    # ── Sweep ───────────────────────────────────────────────────────
+
+    def sweep(self, payload: SweepInput) -> OperationResult:
+        profile = self.store.get(payload.profile_id)
+        if not profile:
+            return self._shape_not_found(payload.profile_id)
+        path = self.store.get(payload.path_id)
+        if not path:
+            return self._shape_not_found(payload.path_id)
+
+        # Union bboxes as approximation
+        bbox = union_bbox(profile.bbox, path.bbox)
+        vol = max(self.tolerance, profile.volume if profile.volume > 0 else bbox.volume() * 0.1)
+        shape_out = self._make_shape(
+            kind="sweep",
+            bbox=bbox,
+            volume=vol,
+            parameters=payload.model_dump(),
+            edge_count=8,
+            face_count=6,
+            source_ids=[profile.id, path.id],
+        )
+        return self._success(shape_out, "sweep")
+
+    # ── Loft ────────────────────────────────────────────────────────
+
+    def loft(self, payload: LoftInput) -> OperationResult:
+        profiles: list[ShapeData] = []
+        for pid in payload.profile_ids:
+            p = self.store.get(pid)
+            if not p:
+                return self._shape_not_found(pid)
+            profiles.append(p)
+
+        # Combine bboxes
+        combined_bbox = profiles[0].bbox
+        for p in profiles[1:]:
+            combined_bbox = union_bbox(combined_bbox, p.bbox)
+        vol = max(self.tolerance, combined_bbox.volume() * 0.5)
+
+        shape_out = self._make_shape(
+            kind="loft",
+            bbox=combined_bbox,
+            volume=vol,
+            parameters=payload.model_dump(),
+            edge_count=max(4, sum(len(p.edge_ids) for p in profiles)),
+            face_count=max(2, len(profiles) + 2),
+            source_ids=payload.profile_ids,
+        )
+        return self._success(shape_out, "loft")
+
+    # ── Linear pattern ──────────────────────────────────────────────
+
+    def linear_pattern(self, payload: LinearPatternInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+        if payload.spacing <= self.tolerance:
+            return self._invalid_input("Pattern spacing must be greater than tolerance.")
+
+        d = _vec3_normalise(payload.direction)
+        total_offset = payload.spacing * (payload.count - 1)
+        bbox = BoundingBox(
+            min_x=shape.bbox.min_x + min(0.0, d[0] * total_offset),
+            min_y=shape.bbox.min_y + min(0.0, d[1] * total_offset),
+            min_z=shape.bbox.min_z + min(0.0, d[2] * total_offset),
+            max_x=shape.bbox.max_x + max(0.0, d[0] * total_offset),
+            max_y=shape.bbox.max_y + max(0.0, d[1] * total_offset),
+            max_z=shape.bbox.max_z + max(0.0, d[2] * total_offset),
+        )
+        shape_out = self._make_shape(
+            kind="linear_pattern",
+            bbox=bbox,
+            volume=shape.volume * payload.count,
+            parameters=payload.model_dump(),
+            edge_count=len(shape.edge_ids) * payload.count,
+            face_count=len(shape.face_ids) * payload.count,
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "linear_pattern")
+
+    # ── Circular pattern ────────────────────────────────────────────
+
+    def circular_pattern(self, payload: CircularPatternInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+
+        # Containing bbox: expand to maximum extent from axis
+        sb = shape.bbox
+        ax = payload.axis_origin
+        max_r = max(
+            math.sqrt((sb.max_x - ax[0]) ** 2 + (sb.max_y - ax[1]) ** 2),
+            math.sqrt((sb.min_x - ax[0]) ** 2 + (sb.min_y - ax[1]) ** 2),
+            math.sqrt((sb.max_x - ax[0]) ** 2 + (sb.min_y - ax[1]) ** 2),
+            math.sqrt((sb.min_x - ax[0]) ** 2 + (sb.max_y - ax[1]) ** 2),
+        )
+        bbox = BoundingBox(
+            min_x=ax[0] - max_r, min_y=ax[1] - max_r, min_z=sb.min_z,
+            max_x=ax[0] + max_r, max_y=ax[1] + max_r, max_z=sb.max_z,
+        )
+        shape_out = self._make_shape(
+            kind="circular_pattern",
+            bbox=bbox,
+            volume=shape.volume * payload.count,
+            parameters=payload.model_dump(),
+            edge_count=len(shape.edge_ids) * payload.count,
+            face_count=len(shape.face_ids) * payload.count,
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "circular_pattern")
+
+    # ── Mirror ──────────────────────────────────────────────────────
+
+    def mirror(self, payload: MirrorInput) -> OperationResult:
+        shape = self.store.get(payload.shape_id)
+        if not shape:
+            return self._shape_not_found(payload.shape_id)
+
+        # Mirror bbox across the plane
+        n = _vec3_normalise(payload.plane_normal)
+        sb = shape.bbox
+
+        def _reflect(pt: tuple[float, float, float]) -> tuple[float, float, float]:
+            ox, oy, oz = payload.plane_origin
+            dx, dy, dz = pt[0] - ox, pt[1] - oy, pt[2] - oz
+            dot = dx * n[0] + dy * n[1] + dz * n[2]
+            return (pt[0] - 2 * dot * n[0], pt[1] - 2 * dot * n[1], pt[2] - 2 * dot * n[2])
+
+        corners = [
+            (sb.min_x, sb.min_y, sb.min_z), (sb.max_x, sb.min_y, sb.min_z),
+            (sb.min_x, sb.max_y, sb.min_z), (sb.max_x, sb.max_y, sb.min_z),
+            (sb.min_x, sb.min_y, sb.max_z), (sb.max_x, sb.min_y, sb.max_z),
+            (sb.min_x, sb.max_y, sb.max_z), (sb.max_x, sb.max_y, sb.max_z),
+        ]
+        mirrored = [_reflect(c) for c in corners]
+        all_pts = corners + mirrored
+        bbox = BoundingBox(
+            min_x=min(p[0] for p in all_pts), min_y=min(p[1] for p in all_pts), min_z=min(p[2] for p in all_pts),
+            max_x=max(p[0] for p in all_pts), max_y=max(p[1] for p in all_pts), max_z=max(p[2] for p in all_pts),
+        )
+        shape_out = self._make_shape(
+            kind="mirror",
+            bbox=bbox,
+            volume=shape.volume * 2,
+            parameters=payload.model_dump(),
+            edge_count=len(shape.edge_ids) * 2,
+            face_count=len(shape.face_ids) * 2,
+            source_ids=[shape.id],
+        )
+        return self._success(shape_out, "mirror")
+
+    # ── Topology ────────────────────────────────────────────────────
+
+    def get_topology(self, shape_id: str) -> TopologyMap:
+        """Return a synthetic topology map for *shape_id*."""
+        shape = self.store.get(shape_id)
+        if shape is None:
+            raise ValueError(f"Shape '{shape_id}' not found.")
+        return build_synthetic_topology(shape.id, shape.kind, shape.bbox, shape.edge_ids)
+
+# ── Utility ─────────────────────────────────────────────────────────
+
+
+def _vec3_normalise(v: tuple[float, float, float]) -> tuple[float, float, float]:
+    ln = math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2)
+    if ln < 1e-12:
+        return (0.0, 0.0, 1.0)
+    return (v[0] / ln, v[1] / ln, v[2] / ln)

--- a/backend/opencad_kernel/core/backend.py
+++ b/backend/opencad_kernel/core/backend.py
@@ -138,3 +138,17 @@ class KernelBackend(Protocol):
     def store(self) -> Any:
         """Return the ShapeStore (or equivalent) held by this backend."""
         ...
+
+
+@runtime_checkable
+class StreamingMeshBackend(KernelBackend, Protocol):
+    """Optional backend capability for face-by-face mesh streaming."""
+
+    def tessellate_face(
+        self,
+        shape_id: str,
+        face_index: int,
+        deflection: float = 0.1,
+    ) -> tuple[MeshData, int]: ...
+
+    def count_faces(self, shape_id: str) -> int: ...

--- a/backend/opencad_kernel/core/op_log.py
+++ b/backend/opencad_kernel/core/op_log.py
@@ -25,6 +25,7 @@ class OpLogEntry(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     operation: str
     version: str
+    backend: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
     result_shape_id: str | None = None
     success: bool = True

--- a/backend/opencad_kernel/operations/handlers.py
+++ b/backend/opencad_kernel/operations/handlers.py
@@ -1,37 +1,28 @@
+"""Kernel coordination layer.
+
+Geometry implementations live in ``opencad_kernel.core`` backends.  This
+module keeps the public ``OpenCadKernel`` entry point stable while owning
+cross-backend concerns such as assembly-mate state and topology selection.
+"""
+
 from __future__ import annotations
 
-import json
-import math
-import struct
-from math import pow
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any
 
-from opencad_kernel.core.checks import check_bbox_overlap, check_manifold, check_nonzero_volume
+from opencad_kernel.core.analytic_backend import AnalyticBackend
+from opencad_kernel.core.backend import KernelBackend
 from opencad_kernel.core.errors import ErrorCode, make_failure
-from opencad_kernel.core.geometry import (
-    box_bbox,
-    box_volume,
-    cylinder_bbox,
-    cylinder_volume,
-    overlap_bbox,
-    overlap_volume,
-    sphere_bbox,
-    sphere_volume,
-    union_bbox,
-)
 from opencad_kernel.core.models import (
     AssemblyMate,
     AssemblyMateStatus,
-    BoundingBox,
     MeshData,
     OperationResult,
     ShapeData,
     Success,
     TopologyMap,
 )
-from opencad_kernel.core.store import IdStrategy, MateStore, ShapeStore
-from opencad_kernel.core.topology import build_synthetic_topology, select as topo_select
+from opencad_kernel.core.store import IdStrategy, MateStore
+from opencad_kernel.core.topology import select as topo_select
 from opencad_kernel.operations.schemas import (
     BooleanInput,
     ChamferEdgesInput,
@@ -62,87 +53,13 @@ from opencad_kernel.operations.schemas import (
     SweepInput,
 )
 
-if TYPE_CHECKING:
-    from opencad_kernel.core.backend import KernelBackend
-
-BooleanOp = Literal["boolean_union", "boolean_cut", "boolean_intersection"]
-
-
-def _read_stl_vertices(filepath: Path) -> list[tuple[float, float, float]]:
-    data = filepath.read_bytes()
-    vertices: list[tuple[float, float, float]] = []
-
-    if data.lstrip().lower().startswith(b"solid"):
-        for line in data.decode("utf-8", errors="ignore").splitlines():
-            fields = line.strip().split()
-            if len(fields) == 4 and fields[0].lower() == "vertex":
-                vertices.append((float(fields[1]), float(fields[2]), float(fields[3])))
-        if vertices:
-            return vertices
-
-    if len(data) < 84:
-        raise ValueError("STL file is too short.")
-    triangle_count = struct.unpack_from("<I", data, 80)[0]
-    expected_size = 84 + triangle_count * 50
-    if len(data) < expected_size:
-        raise ValueError("Binary STL triangle data is truncated.")
-    for triangle_index in range(triangle_count):
-        offset = 84 + triangle_index * 50 + 12
-        coordinates = struct.unpack_from("<9f", data, offset)
-        vertices.extend(
-            (coordinates[index], coordinates[index + 1], coordinates[index + 2])
-            for index in range(0, 9, 3)
-        )
-    return vertices
-
-
-def _triangle_normal(
-    a: tuple[float, float, float],
-    b: tuple[float, float, float],
-    c: tuple[float, float, float],
-) -> tuple[float, float, float]:
-    ux, uy, uz = b[0] - a[0], b[1] - a[1], b[2] - a[2]
-    vx, vy, vz = c[0] - a[0], c[1] - a[1], c[2] - a[2]
-    nx, ny, nz = uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx
-    length = math.sqrt(nx * nx + ny * ny + nz * nz)
-    if length <= 1e-12:
-        return (0.0, 0.0, 0.0)
-    return (nx / length, ny / length, nz / length)
-
-
-def _bbox_stl(shape: ShapeData) -> str:
-    box = shape.bbox
-    points = [
-        (box.min_x, box.min_y, box.min_z),
-        (box.max_x, box.min_y, box.min_z),
-        (box.max_x, box.max_y, box.min_z),
-        (box.min_x, box.max_y, box.min_z),
-        (box.min_x, box.min_y, box.max_z),
-        (box.max_x, box.min_y, box.max_z),
-        (box.max_x, box.max_y, box.max_z),
-        (box.min_x, box.max_y, box.max_z),
-    ]
-    triangles = [
-        (0, 2, 1), (0, 3, 2), (4, 5, 6), (4, 6, 7),
-        (0, 1, 5), (0, 5, 4), (1, 2, 6), (1, 6, 5),
-        (2, 3, 7), (2, 7, 6), (3, 0, 4), (3, 4, 7),
-    ]
-    lines = ["solid opencad"]
-    for first, second, third in triangles:
-        a, b, c = points[first], points[second], points[third]
-        normal = _triangle_normal(a, b, c)
-        lines.append(f"  facet normal {normal[0]} {normal[1]} {normal[2]}")
-        lines.append("    outer loop")
-        for vertex in (a, b, c):
-            lines.append(f"      vertex {vertex[0]} {vertex[1]} {vertex[2]}")
-        lines.extend(("    endloop", "  endfacet"))
-    lines.append("endsolid opencad")
-    return "\n".join(lines) + "\n"
-
 
 class OpenCadKernel:
-    """Geometry kernel — delegates to a :class:`KernelBackend` when one is
-    provided, otherwise falls back to the built-in analytic implementation.
+    """Coordinate application state around a replaceable geometry backend.
+
+    ``AnalyticBackend`` remains the compatibility default for lightweight
+    in-process use.  Production callers can inject ``OcctBackend`` without
+    introducing backend branches into this facade.
     """
 
     def __init__(
@@ -154,20 +71,108 @@ class OpenCadKernel:
     ) -> None:
         self.tolerance = tolerance
         self.allow_partial_boolean = allow_partial_boolean
-        self._backend = backend
-
-        # When delegating, the backend owns the store.
-        if backend is not None:
-            self.store = backend.store
-        else:
-            self.store = ShapeStore(id_strategy=id_strategy)
-
-        # Assembly mate store — always kernel-managed
+        self._backend: KernelBackend = backend or AnalyticBackend(
+            tolerance=tolerance,
+            allow_partial_boolean=allow_partial_boolean,
+            id_strategy=id_strategy,
+        )
+        self.store = self._backend.store
         self.mate_store = MateStore(id_strategy=id_strategy)
 
     @property
-    def backend(self) -> KernelBackend | None:
+    def backend(self) -> KernelBackend:
         return self._backend
+
+    # Geometry methods are explicit so ownership stays searchable and typed.
+
+    def create_box(self, payload: CreateBoxInput) -> OperationResult:
+        return self._backend.create_box(payload)
+
+    def create_cylinder(self, payload: CreateCylinderInput) -> OperationResult:
+        return self._backend.create_cylinder(payload)
+
+    def create_sphere(self, payload: CreateSphereInput) -> OperationResult:
+        return self._backend.create_sphere(payload)
+
+    def create_cone(self, payload: CreateConeInput) -> OperationResult:
+        return self._backend.create_cone(payload)
+
+    def create_torus(self, payload: CreateTorusInput) -> OperationResult:
+        return self._backend.create_torus(payload)
+
+    def boolean_union(self, payload: BooleanInput) -> OperationResult:
+        return self._backend.boolean_union(payload)
+
+    def boolean_cut(self, payload: BooleanInput) -> OperationResult:
+        return self._backend.boolean_cut(payload)
+
+    def boolean_intersection(self, payload: BooleanInput) -> OperationResult:
+        return self._backend.boolean_intersection(payload)
+
+    def fillet_edges(self, payload: FilletEdgesInput) -> OperationResult:
+        return self._backend.fillet_edges(payload)
+
+    def chamfer_edges(self, payload: ChamferEdgesInput) -> OperationResult:
+        return self._backend.chamfer_edges(payload)
+
+    def shell(self, payload: ShellInput) -> OperationResult:
+        return self._backend.shell(payload)
+
+    def draft(self, payload: DraftInput) -> OperationResult:
+        return self._backend.draft(payload)
+
+    def offset_shape(self, payload: OffsetShapeInput) -> OperationResult:
+        return self._backend.offset_shape(payload)
+
+    def create_sketch(self, payload: CreateSketchInput) -> OperationResult:
+        return self._backend.create_sketch(payload)
+
+    def extrude(self, payload: ExtrudeInput) -> OperationResult:
+        return self._backend.extrude(payload)
+
+    def revolve(self, payload: RevolveInput) -> OperationResult:
+        return self._backend.revolve(payload)
+
+    def sweep(self, payload: SweepInput) -> OperationResult:
+        return self._backend.sweep(payload)
+
+    def loft(self, payload: LoftInput) -> OperationResult:
+        return self._backend.loft(payload)
+
+    def linear_pattern(self, payload: LinearPatternInput) -> OperationResult:
+        return self._backend.linear_pattern(payload)
+
+    def circular_pattern(self, payload: CircularPatternInput) -> OperationResult:
+        return self._backend.circular_pattern(payload)
+
+    def mirror(self, payload: MirrorInput) -> OperationResult:
+        return self._backend.mirror(payload)
+
+    def import_step(self, payload: ImportStepInput) -> OperationResult:
+        return self._backend.import_step(payload)
+
+    def export_step(self, payload: ExportStepInput) -> OperationResult:
+        return self._backend.export_step(payload)
+
+    def import_stl(self, payload: ImportStlInput) -> OperationResult:
+        return self._backend.import_stl(payload)
+
+    def export_stl(self, payload: ExportStlInput) -> OperationResult:
+        return self._backend.export_stl(payload)
+
+    def tessellate(self, shape_id: str, deflection: float = 0.1) -> MeshData:
+        return self._backend.tessellate(shape_id, deflection)
+
+    def get_topology(self, shape_id: str) -> TopologyMap:
+        return self._backend.get_topology(shape_id)
+
+    def get_native_shape(self, shape_id: str) -> Any:
+        return self._backend.get_native_shape(shape_id)
+
+    def select_subshapes(self, shape_id: str, query: SelectorQuery) -> list:
+        """Apply the shared selector language to backend topology data."""
+        topology = self._backend.get_topology(shape_id)
+        return topo_select(topology.faces + topology.edges, query)
 
     def _invalid_input(self, message: str) -> OperationResult:
         return make_failure(
@@ -177,878 +182,13 @@ class OpenCadKernel:
             failed_check="input_validation",
         )
 
-    def _shape_not_found(self, shape_id: str) -> OperationResult:
-        return make_failure(
-            code=ErrorCode.SHAPE_NOT_FOUND,
-            message=f"Shape '{shape_id}' was not found.",
-            suggestion="Use an existing shape_id from a previous successful operation.",
-            failed_check="shape_lookup",
-        )
-
-    def _success(self, shape: ShapeData, operation: str, **metadata: object) -> Success:
-        self.store.add(shape)
-        return Success(shape_id=shape.id, shape=shape, metadata={"operation": operation, **metadata})
-
-    def _make_shape(
-        self,
-        kind: str,
-        bbox: BoundingBox,
-        volume: float,
-        parameters: dict[str, object],
-        manifold: bool = True,
-        edge_count: int = 0,
-        face_count: int = 0,
-        source_ids: list[str] | None = None,
-    ) -> ShapeData:
-        shape_id = self.store.new_id(kind)
-        edges = [f"{shape_id}:edge:{idx}" for idx in range(edge_count)]
-        faces = [f"{shape_id}:face:{idx}" for idx in range(face_count)]
-        return ShapeData(
-            id=shape_id,
-            kind=kind,
-            parameters=parameters,
-            bbox=bbox,
-            volume=volume,
-            manifold=manifold,
-            edge_ids=edges,
-            face_ids=faces,
-            source_ids=source_ids or [],
-        )
-
-    def create_box(self, payload: CreateBoxInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_box(payload)
-        if payload.length <= self.tolerance or payload.width <= self.tolerance or payload.height <= self.tolerance:
-            return self._invalid_input("Box dimensions must be greater than tolerance.")
-
-        shape = self._make_shape(
-            kind="box",
-            bbox=box_bbox(payload.length, payload.width, payload.height),
-            volume=box_volume(payload.length, payload.width, payload.height),
-            parameters=payload.model_dump(),
-            edge_count=12,
-            face_count=6,
-        )
-        return self._success(shape, "create_box")
-
-    def create_cylinder(self, payload: CreateCylinderInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_cylinder(payload)
-        if payload.radius <= self.tolerance or payload.height <= self.tolerance:
-            return self._invalid_input("Cylinder radius and height must be greater than tolerance.")
-
-        shape = self._make_shape(
-            kind="cylinder",
-            bbox=cylinder_bbox(payload.radius, payload.height),
-            volume=cylinder_volume(payload.radius, payload.height),
-            parameters=payload.model_dump(),
-            edge_count=3,
-            face_count=3,
-        )
-        return self._success(shape, "create_cylinder")
-
-    def create_sphere(self, payload: CreateSphereInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_sphere(payload)
-        if payload.radius <= self.tolerance:
-            return self._invalid_input("Sphere radius must be greater than tolerance.")
-
-        shape = self._make_shape(
-            kind="sphere",
-            bbox=sphere_bbox(payload.radius),
-            volume=sphere_volume(payload.radius),
-            parameters=payload.model_dump(),
-            edge_count=1,
-            face_count=1,
-        )
-        return self._success(shape, "create_sphere")
-
-    def _fetch_shape_pair(self, payload: BooleanInput) -> tuple[ShapeData, ShapeData] | OperationResult:
-        shape_a = self.store.get(payload.shape_a_id)
-        if not shape_a:
-            return self._shape_not_found(payload.shape_a_id)
-
-        shape_b = self.store.get(payload.shape_b_id)
-        if not shape_b:
-            return self._shape_not_found(payload.shape_b_id)
-
-        return shape_a, shape_b
-
-    def _preflight_boolean(
-        self,
-        op_name: BooleanOp,
-        shape_a: ShapeData,
-        shape_b: ShapeData,
-    ) -> OperationResult | None:
-        volume_a = check_nonzero_volume(shape_a, self.tolerance)
-        if volume_a:
-            return volume_a
-
-        volume_b = check_nonzero_volume(shape_b, self.tolerance)
-        if volume_b:
-            return volume_b
-
-        manifold_a = check_manifold(shape_a)
-        if manifold_a:
-            return manifold_a
-
-        manifold_b = check_manifold(shape_b)
-        if manifold_b:
-            return manifold_b
-
-        if op_name in {"boolean_union", "boolean_intersection"}:
-            overlap = check_bbox_overlap(shape_a, shape_b, self.tolerance)
-            if overlap:
-                return overlap
-
-        return None
-
-    def _run_boolean(self, op_name: BooleanOp, shape_a: ShapeData, shape_b: ShapeData) -> OperationResult:
-        bbox_overlap = overlap_volume(shape_a.bbox, shape_b.bbox)
-        estimated_overlap = min(bbox_overlap, shape_a.volume, shape_b.volume)
-
-        if op_name == "boolean_union":
-            result_volume = shape_a.volume + shape_b.volume - estimated_overlap
-            result_bbox = union_bbox(shape_a.bbox, shape_b.bbox)
-
-        elif op_name == "boolean_cut":
-            result_volume = shape_a.volume - estimated_overlap
-            if result_volume <= self.tolerance:
-                return make_failure(
-                    code=ErrorCode.ZERO_VOLUME,
-                    message="Boolean cut removed all material from the base shape.",
-                    suggestion="Reduce overlap or choose a different cutting shape.",
-                    failed_check="boolean_result_volume",
-                )
-            result_bbox = shape_a.bbox
-
-        else:  # boolean_intersection
-            result_volume = estimated_overlap
-            if result_volume <= self.tolerance:
-                return make_failure(
-                    code=ErrorCode.BBOX_NEAR_TANGENT,
-                    message="Intersection produced near-zero volume.",
-                    suggestion="Increase overlap between shapes before intersection.",
-                    failed_check="boolean_result_volume",
-                )
-            result_bbox = overlap_bbox(shape_a.bbox, shape_b.bbox)
-
-        result = self._make_shape(
-            kind=op_name,
-            bbox=result_bbox,
-            volume=result_volume,
-            parameters={"shape_a_id": shape_a.id, "shape_b_id": shape_b.id},
-            edge_count=max(1, len(shape_a.edge_ids) + len(shape_b.edge_ids)),
-            source_ids=[shape_a.id, shape_b.id],
-        )
-        return self._success(result, op_name, preflight="passed")
-
-    def _boolean(self, op_name: BooleanOp, payload: BooleanInput) -> OperationResult:
-        pair = self._fetch_shape_pair(payload)
-        if not isinstance(pair, tuple):
-            return pair
-
-        shape_a, shape_b = pair
-        preflight = self._preflight_boolean(op_name, shape_a, shape_b)
-        if preflight is not None:
-            return preflight
-
-        try:
-            return self._run_boolean(op_name, shape_a, shape_b)
-        except Exception as exc:  # pragma: no cover
-            return make_failure(
-                code=ErrorCode.BOOLEAN_KERNEL_ERROR,
-                message=f"Boolean operation failed: {exc}",
-                suggestion="Inspect input geometry and retry with cleaned shapes.",
-                failed_check="kernel_execution",
-            )
-
-    def boolean_union(self, payload: BooleanInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.boolean_union(payload)
-        return self._boolean("boolean_union", payload)
-
-    def boolean_cut(self, payload: BooleanInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.boolean_cut(payload)
-        return self._boolean("boolean_cut", payload)
-
-    def boolean_intersection(self, payload: BooleanInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.boolean_intersection(payload)
-        return self._boolean("boolean_intersection", payload)
-
-    def fillet_edges(self, payload: FilletEdgesInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.fillet_edges(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-
-        if not payload.edge_ids:
-            return self._invalid_input("At least one edge_id is required for fillet.")
-        if payload.radius <= self.tolerance:
-            return self._invalid_input("Fillet radius must be greater than tolerance.")
-
-        dx = shape.bbox.max_x - shape.bbox.min_x
-        dy = shape.bbox.max_y - shape.bbox.min_y
-        dz = shape.bbox.max_z - shape.bbox.min_z
-        max_radius = max(self.tolerance, min(dx, dy, dz) / 2.0)
-        if payload.radius >= max_radius:
-            return make_failure(
-                code=ErrorCode.FILLET_RADIUS_TOO_LARGE,
-                message=f"Fillet radius {payload.radius} exceeds max allowed {max_radius:.6f}.",
-                suggestion="Reduce fillet radius or increase base feature size.",
-                failed_check="fillet_radius",
-            )
-
-        reduction = min(0.5, 0.02 * len(payload.edge_ids))
-        shape_out = self._make_shape(
-            kind="fillet",
-            bbox=shape.bbox,
-            volume=max(self.tolerance, shape.volume * (1.0 - reduction)),
-            parameters={"shape_id": payload.shape_id, "edge_ids": payload.edge_ids, "radius": payload.radius},
-            edge_count=max(1, len(shape.edge_ids)),
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "fillet_edges")
-
-    def offset_shape(self, payload: OffsetShapeInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.offset_shape(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-
-        dx = shape.bbox.max_x - shape.bbox.min_x
-        dy = shape.bbox.max_y - shape.bbox.min_y
-        dz = shape.bbox.max_z - shape.bbox.min_z
-        if payload.distance < 0 and (dx + (2 * payload.distance) <= self.tolerance or dy + (2 * payload.distance) <= self.tolerance or dz + (2 * payload.distance) <= self.tolerance):
-            return make_failure(
-                code=ErrorCode.OFFSET_COLLAPSE,
-                message="Negative offset collapses the shape.",
-                suggestion="Use a smaller negative offset or a positive offset.",
-                failed_check="offset_validity",
-            )
-
-        out_bbox = BoundingBox(
-            min_x=shape.bbox.min_x - payload.distance,
-            min_y=shape.bbox.min_y - payload.distance,
-            min_z=shape.bbox.min_z - payload.distance,
-            max_x=shape.bbox.max_x + payload.distance,
-            max_y=shape.bbox.max_y + payload.distance,
-            max_z=shape.bbox.max_z + payload.distance,
-        )
-
-        out_shape = self._make_shape(
-            kind="offset",
-            bbox=out_bbox,
-            volume=max(self.tolerance, out_bbox.volume()),
-            parameters={"shape_id": payload.shape_id, "distance": payload.distance},
-            edge_count=max(1, len(shape.edge_ids)),
-            source_ids=[shape.id],
-        )
-        return self._success(out_shape, "offset_shape")
-
-    def import_step(self, payload: ImportStepInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.import_step(payload)
-        filepath = Path(payload.filepath)
-        if filepath.suffix.lower() not in {".step", ".stp"}:
-            return make_failure(
-                code=ErrorCode.UNSUPPORTED_STEP,
-                message="Only .step and .stp files are supported.",
-                suggestion="Convert the source file to STEP format.",
-                failed_check="step_extension",
-            )
-
-        try:
-            text = filepath.read_text(encoding="utf-8")
-        except OSError as exc:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message=f"Failed to read STEP file: {exc}",
-                suggestion="Verify file path and read permissions.",
-                failed_check="step_io",
-            )
-
-        parsed: dict[str, object] = {}
-        lines = text.splitlines()
-        if lines and lines[0].strip() == "OPENCAD-MOCK" and len(lines) > 1:
-            try:
-                parsed = json.loads(lines[1])
-            except json.JSONDecodeError:
-                parsed = {}
-
-        if "bbox" in parsed and isinstance(parsed["bbox"], dict):
-            bbox = BoundingBox.model_validate(parsed["bbox"])
-            volume = float(parsed.get("volume", bbox.volume()))
-        else:
-            approx_volume = max(1.0, len(text) * 1e-3)
-            side = pow(approx_volume, 1.0 / 3.0)
-            bbox = BoundingBox(min_x=0.0, min_y=0.0, min_z=0.0, max_x=side, max_y=side, max_z=side)
-            volume = approx_volume
-
-        shape = self._make_shape(
-            kind="imported_step",
-            bbox=bbox,
-            volume=volume,
-            parameters={"filepath": payload.filepath},
-            edge_count=12,
-        )
-        return self._success(shape, "import_step", imported_from=payload.filepath)
-
-    def export_step(self, payload: ExportStepInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.export_step(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-
-        filepath = Path(payload.filepath)
-        payload_data = {
-            "shape_id": shape.id,
-            "kind": shape.kind,
-            "volume": shape.volume,
-            "bbox": shape.bbox.model_dump(),
-            "parameters": shape.parameters,
-        }
-        try:
-            filepath.write_text(f"OPENCAD-MOCK\n{json.dumps(payload_data)}\n", encoding="utf-8")
-        except OSError as exc:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message=f"Failed to write STEP file: {exc}",
-                suggestion="Verify destination directory permissions.",
-                failed_check="step_io",
-            )
-
-        return Success(shape_id=shape.id, shape=None, metadata={"operation": "export_step", "filepath": payload.filepath})
-
-    def import_stl(self, payload: ImportStlInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.import_stl(payload)
-        filepath = Path(payload.filepath)
-        if filepath.suffix.lower() != ".stl":
-            return make_failure(
-                code=ErrorCode.UNSUPPORTED_FILE_FORMAT,
-                message="STL import requires a .stl file.",
-                suggestion="Choose an STL file.",
-                failed_check="stl_extension",
-            )
-        try:
-            vertices = _read_stl_vertices(filepath)
-        except (OSError, ValueError, struct.error) as exc:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message=f"Failed to read STL file: {exc}",
-                suggestion="Verify that the file is a valid ASCII or binary STL.",
-                failed_check="stl_io",
-            )
-        if len(vertices) < 3:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message="STL file contains no triangles.",
-                suggestion="Choose a non-empty STL file.",
-                failed_check="stl_geometry",
-            )
-        xs, ys, zs = zip(*vertices)
-        bbox = BoundingBox(
-            min_x=min(xs), min_y=min(ys), min_z=min(zs),
-            max_x=max(xs), max_y=max(ys), max_z=max(zs),
-        )
-        shape = self._make_shape(
-            kind="imported_stl",
-            bbox=bbox,
-            volume=max(self.tolerance, bbox.volume()),
-            parameters={"filepath": payload.filepath},
-            edge_count=len(vertices),
-            face_count=len(vertices) // 3,
-        )
-        return self._success(shape, "import_stl", imported_from=payload.filepath)
-
-    def export_stl(self, payload: ExportStlInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.export_stl(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        filepath = Path(payload.filepath)
-        if filepath.suffix.lower() != ".stl":
-            return make_failure(
-                code=ErrorCode.UNSUPPORTED_FILE_FORMAT,
-                message="STL export requires a .stl destination.",
-                suggestion="Use a filename ending in .stl.",
-                failed_check="stl_extension",
-            )
-        try:
-            filepath.write_text(_bbox_stl(shape), encoding="utf-8")
-        except OSError as exc:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message=f"Failed to write STL file: {exc}",
-                suggestion="Verify destination directory permissions.",
-                failed_check="stl_io",
-            )
-        return Success(shape_id=shape.id, shape=None, metadata={"operation": "export_stl", "filepath": payload.filepath})
-
-    # ── Tessellation (delegates to backend) ─────────────────────────
-
-    def tessellate(self, shape_id: str, deflection: float = 0.1) -> MeshData:
-        """Tessellate the shape identified by *shape_id*.
-
-        Requires an OCCT (or other tessellation-capable) backend.
-        The analytic fallback kernel cannot produce mesh data.
-        """
-        if self._backend is not None:
-            return self._backend.tessellate(shape_id, deflection)
-        raise NotImplementedError(
-            "Tessellation requires an OCCT backend.  "
-            "Start the kernel with OPENCAD_KERNEL_BACKEND=occt."
-        )
-
-    def get_native_shape(self, shape_id: str) -> Any:
-        if self._backend is not None:
-            return self._backend.get_native_shape(shape_id)
-        return None
-
-    # ── Additional primitives ───────────────────────────────────────
-
-    def create_cone(self, payload: CreateConeInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_cone(payload)
-        if payload.height <= self.tolerance:
-            return self._invalid_input("Cone height must be greater than tolerance.")
-        if payload.radius1 <= self.tolerance and payload.radius2 <= self.tolerance:
-            return self._invalid_input("At least one cone radius must be greater than tolerance.")
-
-        r1, r2, h = payload.radius1, payload.radius2, payload.height
-        r_max = max(r1, r2)
-        vol = (math.pi * h / 3.0) * (r1 ** 2 + r2 ** 2 + r1 * r2)
-        bbox = BoundingBox(min_x=-r_max, min_y=-r_max, min_z=0.0, max_x=r_max, max_y=r_max, max_z=h)
-        shape = self._make_shape("cone", bbox, vol, payload.model_dump(), edge_count=3, face_count=3)
-        return self._success(shape, "create_cone")
-
-    def create_torus(self, payload: CreateTorusInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_torus(payload)
-        if payload.major_radius <= self.tolerance or payload.minor_radius <= self.tolerance:
-            return self._invalid_input("Torus radii must be greater than tolerance.")
-        if payload.minor_radius >= payload.major_radius:
-            return self._invalid_input("Minor radius must be less than major radius.")
-
-        R, r = payload.major_radius, payload.minor_radius
-        vol = 2 * math.pi ** 2 * R * r ** 2
-        outer = R + r
-        bbox = BoundingBox(min_x=-outer, min_y=-outer, min_z=-r, max_x=outer, max_y=outer, max_z=r)
-        shape = self._make_shape("torus", bbox, vol, payload.model_dump(), edge_count=2, face_count=1)
-        return self._success(shape, "create_torus")
-
-    # ── Chamfer ─────────────────────────────────────────────────────
-
-    def chamfer_edges(self, payload: ChamferEdgesInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.chamfer_edges(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        if not payload.edge_ids:
-            return self._invalid_input("At least one edge_id is required for chamfer.")
-        if payload.distance <= self.tolerance:
-            return self._invalid_input("Chamfer distance must be greater than tolerance.")
-
-        reduction = min(0.5, 0.015 * len(payload.edge_ids))
-        shape_out = self._make_shape(
-            kind="chamfer",
-            bbox=shape.bbox,
-            volume=max(self.tolerance, shape.volume * (1.0 - reduction)),
-            parameters={"shape_id": payload.shape_id, "edge_ids": payload.edge_ids, "distance": payload.distance},
-            edge_count=max(1, len(shape.edge_ids) + len(payload.edge_ids)),
-            face_count=max(1, len(shape.face_ids) + len(payload.edge_ids)),
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "chamfer_edges")
-
-    # ── Shell ───────────────────────────────────────────────────────
-
-    def shell(self, payload: ShellInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.shell(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        if payload.thickness <= self.tolerance:
-            return self._invalid_input("Shell thickness must be greater than tolerance.")
-
-        # Heuristic: shell removes volume proportional to thickness
-        dx = shape.bbox.max_x - shape.bbox.min_x
-        dy = shape.bbox.max_y - shape.bbox.min_y
-        dz = shape.bbox.max_z - shape.bbox.min_z
-        inner_vol = max(0.0, (dx - 2 * payload.thickness) * (dy - 2 * payload.thickness) * (dz - 2 * payload.thickness))
-        if inner_vol <= self.tolerance:
-            return make_failure(
-                code=ErrorCode.SHELL_FAILURE,
-                message="Shell thickness too large — would consume entire solid.",
-                suggestion="Reduce shell thickness.",
-                failed_check="shell_validity",
-            )
-
-        shell_vol = shape.volume - inner_vol
-        shape_out = self._make_shape(
-            kind="shell",
-            bbox=shape.bbox,
-            volume=max(self.tolerance, shell_vol),
-            parameters={"shape_id": payload.shape_id, "face_ids": payload.face_ids, "thickness": payload.thickness},
-            edge_count=max(1, len(shape.edge_ids) * 2),
-            face_count=max(1, len(shape.face_ids) * 2 - len(payload.face_ids)),
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "shell")
-
-    # ── Draft ───────────────────────────────────────────────────────
-
-    def draft(self, payload: DraftInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.draft(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        if not payload.face_ids:
-            return self._invalid_input("At least one face_id is required for draft.")
-        if abs(payload.angle) <= self.tolerance:
-            return self._invalid_input("Draft angle must be non-zero.")
-        if abs(payload.angle) >= 90.0:
-            return self._invalid_input("Draft angle must be less than 90 degrees.")
-
-        # Draft slightly expands bbox
-        tan_a = math.tan(math.radians(abs(payload.angle)))
-        expand = tan_a * (shape.bbox.max_z - shape.bbox.min_z) * 0.5
-        draft_bbox = BoundingBox(
-            min_x=shape.bbox.min_x - expand, min_y=shape.bbox.min_y - expand, min_z=shape.bbox.min_z,
-            max_x=shape.bbox.max_x + expand, max_y=shape.bbox.max_y + expand, max_z=shape.bbox.max_z,
-        )
-        shape_out = self._make_shape(
-            kind="draft",
-            bbox=draft_bbox,
-            volume=max(self.tolerance, shape.volume * (1.0 + 0.01 * abs(payload.angle))),
-            parameters=payload.model_dump(),
-            edge_count=max(1, len(shape.edge_ids)),
-            face_count=max(1, len(shape.face_ids)),
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "draft")
-
-    # ── Sketch operations ───────────────────────────────────────────
-
-    def create_sketch(self, payload: CreateSketchInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.create_sketch(payload)
-        if not payload.segments:
-            return self._invalid_input("Sketch must contain at least one segment.")
-
-        # Compute bounding box of 2D segments
-        xs: list[float] = []
-        ys: list[float] = []
-        for seg in payload.segments:
-            if seg.start:
-                xs.append(seg.start[0]); ys.append(seg.start[1])
-            if seg.end:
-                xs.append(seg.end[0]); ys.append(seg.end[1])
-            if seg.center:
-                r = seg.radius or 0.0
-                xs.extend([seg.center[0] - r, seg.center[0] + r])
-                ys.extend([seg.center[1] - r, seg.center[1] + r])
-
-        if not xs:
-            return self._invalid_input("Sketch segments have no defined points.")
-
-        ox, oy, oz = payload.origin
-        # Map 2D bbox to 3D based on plane
-        min2x, max2x = min(xs), max(xs)
-        min2y, max2y = min(ys), max(ys)
-        if payload.plane == "XZ":
-            bbox = BoundingBox(min_x=ox + min2x, min_y=oy, min_z=oz + min2y,
-                               max_x=ox + max2x, max_y=oy, max_z=oz + max2y)
-        elif payload.plane == "YZ":
-            bbox = BoundingBox(min_x=ox, min_y=oy + min2x, min_z=oz + min2y,
-                               max_x=ox, max_y=oy + max2x, max_z=oz + max2y)
-        else:  # XY
-            bbox = BoundingBox(min_x=ox + min2x, min_y=oy + min2y, min_z=oz,
-                               max_x=ox + max2x, max_y=oy + max2y, max_z=oz)
-
-        shape = self._make_shape(
-            kind="sketch",
-            bbox=bbox,
-            volume=0.0,
-            parameters=payload.model_dump(),
-            manifold=False,
-            edge_count=len(payload.segments),
-            face_count=0,
-        )
-        return self._success(shape, "create_sketch")
-
-    def extrude(self, payload: ExtrudeInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.extrude(payload)
-        sketch = self.store.get(payload.sketch_id)
-        if not sketch:
-            return self._shape_not_found(payload.sketch_id)
-        if abs(payload.distance) <= self.tolerance:
-            return self._invalid_input("Extrude distance must be non-zero.")
-
-        d = abs(payload.distance)
-        if payload.both:
-            d *= 2
-        sb = sketch.bbox
-        # Extrude along Z (most common; sketch plane defines this)
-        bbox = BoundingBox(
-            min_x=sb.min_x, min_y=sb.min_y,
-            min_z=sb.min_z - (d / 2 if payload.both else 0.0),
-            max_x=sb.max_x, max_y=sb.max_y,
-            max_z=sb.max_z + (d / 2 if payload.both else d),
-        )
-        area_2d = max(self.tolerance, (sb.max_x - sb.min_x) * (sb.max_y - sb.min_y))
-        vol = area_2d * d
-        shape = self._make_shape(
-            kind="extrude",
-            bbox=bbox,
-            volume=vol,
-            parameters=payload.model_dump(),
-            edge_count=12,
-            face_count=6,
-            source_ids=[sketch.id],
-        )
-        return self._success(shape, "extrude")
-
-    # ── Revolve ─────────────────────────────────────────────────────
-
-    def revolve(self, payload: RevolveInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.revolve(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        if abs(payload.angle) <= self.tolerance:
-            return self._invalid_input("Revolve angle must be non-zero.")
-
-        # Estimate: revolve the profile's bbox extent around the axis
-        sb = shape.bbox
-        max_extent = max(
-            abs(sb.max_x - payload.axis_origin[0]),
-            abs(sb.min_x - payload.axis_origin[0]),
-            abs(sb.max_y - payload.axis_origin[1]),
-            abs(sb.min_y - payload.axis_origin[1]),
-        )
-        h = sb.max_z - sb.min_z
-        frac = min(abs(payload.angle), 360.0) / 360.0
-        vol = math.pi * max_extent ** 2 * max(h, self.tolerance) * frac
-        bbox = BoundingBox(
-            min_x=-max_extent, min_y=-max_extent, min_z=sb.min_z,
-            max_x=max_extent, max_y=max_extent, max_z=sb.max_z,
-        )
-        shape_out = self._make_shape(
-            kind="revolve",
-            bbox=bbox,
-            volume=vol,
-            parameters=payload.model_dump(),
-            edge_count=4,
-            face_count=4,
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "revolve")
-
-    # ── Sweep ───────────────────────────────────────────────────────
-
-    def sweep(self, payload: SweepInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.sweep(payload)
-        profile = self.store.get(payload.profile_id)
-        if not profile:
-            return self._shape_not_found(payload.profile_id)
-        path = self.store.get(payload.path_id)
-        if not path:
-            return self._shape_not_found(payload.path_id)
-
-        # Union bboxes as approximation
-        bbox = union_bbox(profile.bbox, path.bbox)
-        vol = max(self.tolerance, profile.volume if profile.volume > 0 else bbox.volume() * 0.1)
-        shape_out = self._make_shape(
-            kind="sweep",
-            bbox=bbox,
-            volume=vol,
-            parameters=payload.model_dump(),
-            edge_count=8,
-            face_count=6,
-            source_ids=[profile.id, path.id],
-        )
-        return self._success(shape_out, "sweep")
-
-    # ── Loft ────────────────────────────────────────────────────────
-
-    def loft(self, payload: LoftInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.loft(payload)
-        profiles: list[ShapeData] = []
-        for pid in payload.profile_ids:
-            p = self.store.get(pid)
-            if not p:
-                return self._shape_not_found(pid)
-            profiles.append(p)
-
-        # Combine bboxes
-        combined_bbox = profiles[0].bbox
-        for p in profiles[1:]:
-            combined_bbox = union_bbox(combined_bbox, p.bbox)
-        vol = max(self.tolerance, combined_bbox.volume() * 0.5)
-
-        shape_out = self._make_shape(
-            kind="loft",
-            bbox=combined_bbox,
-            volume=vol,
-            parameters=payload.model_dump(),
-            edge_count=max(4, sum(len(p.edge_ids) for p in profiles)),
-            face_count=max(2, len(profiles) + 2),
-            source_ids=payload.profile_ids,
-        )
-        return self._success(shape_out, "loft")
-
-    # ── Linear pattern ──────────────────────────────────────────────
-
-    def linear_pattern(self, payload: LinearPatternInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.linear_pattern(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-        if payload.spacing <= self.tolerance:
-            return self._invalid_input("Pattern spacing must be greater than tolerance.")
-
-        d = _vec3_normalise(payload.direction)
-        total_offset = payload.spacing * (payload.count - 1)
-        bbox = BoundingBox(
-            min_x=shape.bbox.min_x + min(0.0, d[0] * total_offset),
-            min_y=shape.bbox.min_y + min(0.0, d[1] * total_offset),
-            min_z=shape.bbox.min_z + min(0.0, d[2] * total_offset),
-            max_x=shape.bbox.max_x + max(0.0, d[0] * total_offset),
-            max_y=shape.bbox.max_y + max(0.0, d[1] * total_offset),
-            max_z=shape.bbox.max_z + max(0.0, d[2] * total_offset),
-        )
-        shape_out = self._make_shape(
-            kind="linear_pattern",
-            bbox=bbox,
-            volume=shape.volume * payload.count,
-            parameters=payload.model_dump(),
-            edge_count=len(shape.edge_ids) * payload.count,
-            face_count=len(shape.face_ids) * payload.count,
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "linear_pattern")
-
-    # ── Circular pattern ────────────────────────────────────────────
-
-    def circular_pattern(self, payload: CircularPatternInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.circular_pattern(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-
-        # Containing bbox: expand to maximum extent from axis
-        sb = shape.bbox
-        ax = payload.axis_origin
-        max_r = max(
-            math.sqrt((sb.max_x - ax[0]) ** 2 + (sb.max_y - ax[1]) ** 2),
-            math.sqrt((sb.min_x - ax[0]) ** 2 + (sb.min_y - ax[1]) ** 2),
-            math.sqrt((sb.max_x - ax[0]) ** 2 + (sb.min_y - ax[1]) ** 2),
-            math.sqrt((sb.min_x - ax[0]) ** 2 + (sb.max_y - ax[1]) ** 2),
-        )
-        bbox = BoundingBox(
-            min_x=ax[0] - max_r, min_y=ax[1] - max_r, min_z=sb.min_z,
-            max_x=ax[0] + max_r, max_y=ax[1] + max_r, max_z=sb.max_z,
-        )
-        shape_out = self._make_shape(
-            kind="circular_pattern",
-            bbox=bbox,
-            volume=shape.volume * payload.count,
-            parameters=payload.model_dump(),
-            edge_count=len(shape.edge_ids) * payload.count,
-            face_count=len(shape.face_ids) * payload.count,
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "circular_pattern")
-
-    # ── Mirror ──────────────────────────────────────────────────────
-
-    def mirror(self, payload: MirrorInput) -> OperationResult:
-        if self._backend is not None:
-            return self._backend.mirror(payload)
-        shape = self.store.get(payload.shape_id)
-        if not shape:
-            return self._shape_not_found(payload.shape_id)
-
-        # Mirror bbox across the plane
-        n = _vec3_normalise(payload.plane_normal)
-        sb = shape.bbox
-
-        def _reflect(pt: tuple[float, float, float]) -> tuple[float, float, float]:
-            ox, oy, oz = payload.plane_origin
-            dx, dy, dz = pt[0] - ox, pt[1] - oy, pt[2] - oz
-            dot = dx * n[0] + dy * n[1] + dz * n[2]
-            return (pt[0] - 2 * dot * n[0], pt[1] - 2 * dot * n[1], pt[2] - 2 * dot * n[2])
-
-        corners = [
-            (sb.min_x, sb.min_y, sb.min_z), (sb.max_x, sb.min_y, sb.min_z),
-            (sb.min_x, sb.max_y, sb.min_z), (sb.max_x, sb.max_y, sb.min_z),
-            (sb.min_x, sb.min_y, sb.max_z), (sb.max_x, sb.min_y, sb.max_z),
-            (sb.min_x, sb.max_y, sb.max_z), (sb.max_x, sb.max_y, sb.max_z),
-        ]
-        mirrored = [_reflect(c) for c in corners]
-        all_pts = corners + mirrored
-        bbox = BoundingBox(
-            min_x=min(p[0] for p in all_pts), min_y=min(p[1] for p in all_pts), min_z=min(p[2] for p in all_pts),
-            max_x=max(p[0] for p in all_pts), max_y=max(p[1] for p in all_pts), max_z=max(p[2] for p in all_pts),
-        )
-        shape_out = self._make_shape(
-            kind="mirror",
-            bbox=bbox,
-            volume=shape.volume * 2,
-            parameters=payload.model_dump(),
-            edge_count=len(shape.edge_ids) * 2,
-            face_count=len(shape.face_ids) * 2,
-            source_ids=[shape.id],
-        )
-        return self._success(shape_out, "mirror")
-
-    # ── Topology ────────────────────────────────────────────────────
-
-    def get_topology(self, shape_id: str) -> TopologyMap:
-        """Return topology map for *shape_id*.
-
-        Delegates to backend when present; otherwise builds a synthetic map.
-        """
-        if self._backend is not None:
-            return self._backend.get_topology(shape_id)
-        shape = self.store.get(shape_id)
-        if shape is None:
-            raise ValueError(f"Shape '{shape_id}' not found.")
-        return build_synthetic_topology(shape.id, shape.kind, shape.bbox, shape.edge_ids)
-
-    def select_subshapes(self, shape_id: str, query: SelectorQuery) -> list:
-        """Run a selector query against a shape's topology."""
-        topo = self.get_topology(shape_id)
-        all_refs = topo.faces + topo.edges
-        return topo_select(all_refs, query)
-
-    # ── Assembly mates (3-D constraints — Phase 1) ──────────────────
-
     def _resolve_entity_shape(self, entity_ref: str) -> ShapeData | None:
-        """Extract shape_id from an entity reference like ``box-0001:face:0``."""
+        """Extract a shape ID from a reference such as ``box-0001:face:0``."""
         shape_id = entity_ref.split(":")[0] if ":" in entity_ref else entity_ref
         return self.store.get(shape_id)
 
     def create_assembly_mate(self, payload: CreateAssemblyMateInput) -> OperationResult:
         """Create a 3-D assembly mate between two entity references."""
-        # Validate entity A
         shape_a = self._resolve_entity_shape(payload.entity_a)
         if shape_a is None:
             return make_failure(
@@ -1058,7 +198,6 @@ class OpenCadKernel:
                 failed_check="mate_entity_a_lookup",
             )
 
-        # Validate entity B
         shape_b = self._resolve_entity_shape(payload.entity_b)
         if shape_b is None:
             return make_failure(
@@ -1068,19 +207,13 @@ class OpenCadKernel:
                 failed_check="mate_entity_b_lookup",
             )
 
-        # Value required for distance/angle mates
         if payload.type.value in ("distance", "angle") and payload.value is None:
             return self._invalid_input(
                 f"Assembly mate type '{payload.type.value}' requires a numeric 'value'."
             )
 
-        # Check for duplicate mate
-        existing = self.mate_store.by_entity(payload.entity_a)
-        for mate in existing:
-            if (
-                mate.entity_b == payload.entity_b
-                and mate.type == payload.type.value
-            ):
+        for mate in self.mate_store.by_entity(payload.entity_a):
+            if mate.entity_b == payload.entity_b and mate.type == payload.type.value:
                 return make_failure(
                     code=ErrorCode.MATE_DUPLICATE,
                     message=f"A '{payload.type.value}' mate already exists between these entities.",
@@ -1088,9 +221,8 @@ class OpenCadKernel:
                     failed_check="mate_duplicate_check",
                 )
 
-        mate_id = self.mate_store.new_id()
         mate = AssemblyMate(
-            id=mate_id,
+            id=self.mate_store.new_id(),
             type=payload.type.value,
             entity_a=payload.entity_a,
             entity_b=payload.entity_b,
@@ -1125,25 +257,16 @@ class OpenCadKernel:
 
     def list_assembly_mates(self, payload: ListAssemblyMatesInput) -> OperationResult:
         """List mates, optionally filtered by entity involvement."""
-        if payload.entity_ref:
-            mates = self.mate_store.by_entity(payload.entity_ref)
-        else:
-            mates = self.mate_store.all()
+        mates = (
+            self.mate_store.by_entity(payload.entity_ref)
+            if payload.entity_ref
+            else self.mate_store.all()
+        )
         return Success(
             shape_id=None,
             shape=None,
             metadata={
                 "operation": "list_assembly_mates",
-                "mates": [m.model_dump() for m in mates],
+                "mates": [mate.model_dump() for mate in mates],
             },
         )
-
-
-# ── Utility ─────────────────────────────────────────────────────────
-
-
-def _vec3_normalise(v: tuple[float, float, float]) -> tuple[float, float, float]:
-    ln = math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2)
-    if ln < 1e-12:
-        return (0.0, 0.0, 1.0)
-    return (v[0] / ln, v[1] / ln, v[2] / ln)

--- a/backend/opencad_kernel/operations/registry.py
+++ b/backend/opencad_kernel/operations/registry.py
@@ -166,6 +166,7 @@ class OperationRegistry:
         entry_kwargs: dict[str, Any] = {
             "operation": name,
             "version": spec.version,
+            "backend": type(self.kernel.backend).__name__,
             "params": payload,
             "result_shape_id": result.shape_id if is_success else None,
             "success": is_success,

--- a/backend/opencad_kernel/tests/test_op_log.py
+++ b/backend/opencad_kernel/tests/test_op_log.py
@@ -76,6 +76,7 @@ def test_successful_operation_is_logged(registry: OperationRegistry):
     assert entry.version == "1.0.0"
     assert entry.success is True
     assert entry.result_shape_id == result.shape_id
+    assert entry.backend == "AnalyticBackend"
     assert entry.duration_ms >= 0.0
     assert entry.params == {"length": 2.0, "width": 3.0, "height": 4.0}
 

--- a/backend/opencad_kernel/tests/test_operations.py
+++ b/backend/opencad_kernel/tests/test_operations.py
@@ -313,7 +313,7 @@ def test_boolean_kernel_exception_is_caught(kernel: OpenCadKernel, monkeypatch) 
     def _boom(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(kernel, "_run_boolean", _boom)
+    monkeypatch.setattr(kernel.backend, "_run_boolean", _boom)
     result = kernel.boolean_union(BooleanInput(shape_a_id=a_id, shape_b_id=b_id))
     assert isinstance(result, Failure)
     assert result.code == ErrorCode.BOOLEAN_KERNEL_ERROR


### PR DESCRIPTION
## Summary
- move analytic geometry into an explicit `AnalyticBackend`
- reduce `OpenCadKernel` to a typed coordinator for geometry, topology selection, and assembly mates
- add explicit streaming-mesh capability tracking and backend identity in operation logs
- allow `RuntimeContext` backend injection and document the boundary

## Validation
- `uv run pytest -q backend/opencad_kernel/tests --ignore=backend/opencad_kernel/tests/test_occt_backend.py backend/opencad/tests/test_kernel_adapter.py backend/opencad_agent/tests/test_toolruntime_live_sketch.py` (123 passed)
- `uv run pytest -q backend/opencad_kernel/tests/test_occt_backend.py::test_kernel_with_occt_backend` (passed)
- `python -m compileall -q backend`