### PR TITLE
Use native torus operation in agent output

### DIFF
--- a/backend/opencad_agent/prompting.py
+++ b/backend/opencad_agent/prompting.py
@@ -16,13 +16,7 @@ def build_system_prompt(tree_state: FeatureTree) -> str:
         f"{tree_json}\n"
         "\n"
         "Available operations and their schemas:\n"
-        "- add_sketch(name, entities, constraints) -> sketch_id\n"
-        "- extrude(sketch_id, depth, name) -> feature_id\n"
-        "- boolean_cut(base_id, tool_id, name) -> feature_id\n"
-        "- fillet_edges(shape_id, edge_selection, radius, name) -> feature_id\n"
-        "- add_cylinder(position, radius, height, name) -> feature_id\n"
-        "- get_tree_state() -> FeatureTree JSON\n"
-        "- get_shape_info(shape_id) -> dimensions, volume, surface_area\n"
+        f"{_API_REFERENCE}\n"
         "\n"
         "Parametric features:\n"
         "- Nodes may have typed_parameters and parameter_bindings.\n"
@@ -65,11 +59,16 @@ Part methods (all return self for chaining):
   .box(length, width, height, *, name=str)
   .cylinder(radius, height, *, name=str)
   .sphere(radius, *, name=str)
+  .cone(radius1, radius2, height, *, name=str)
+  .torus(major_radius, minor_radius, *, name=str)
   .extrude(sketch, *, depth, both=False, name=str)   # sketch is a Sketch instance, NO subtract arg
   .union(other_part, *, name=str)
   .cut(other_part, *, name=str)
+  .intersect(other_part, *, name=str)
   .fillet(*, edges=None|"all"|"top"|[id,...], radius, name=str)
   .chamfer(*, edges=None|"all"|"top"|[id,...], distance, name=str)
+  .shell(*, face_ids=[id,...], thickness, name=str)
+  .draft(*, face_ids=[id,...], angle, pull_direction=(x,y,z), name=str)
   .offset(distance, *, name=str)
   .linear_pattern(*, direction=(x,y,z), count, spacing, name=str)
   .circular_pattern(*, axis_origin=(x,y,z), axis_direction=(x,y,z), count, angle=360.0, name=str)
@@ -116,6 +115,8 @@ def build_code_generation_prompt(tree_state: FeatureTree) -> str:
         "- Constructors are keyword-only: always write `Part(name=...)` and pass only named arguments to `Sketch(...)`.\n"
         "- Prefer `Sketch(name=...)`; if origin is supplied it must be a 3-number tuple, while rect origin and circle center use 2-number tuples.\n"
         "- Create each independent solid from its own Part instance; do not call an operation on a Part that has no shape.\n"
+        "- Use the native box, cylinder, sphere, cone, or torus Part method whenever that primitive is requested; do not approximate it with a sketch and extrusion.\n"
+        "- A torus must use `Part(name=...).torus(major_radius=..., minor_radius=..., name=...)`.\n"
         "- For radial repetition, sketch one feature away from the axis, extrude it, then use circular_pattern and union it with the core.\n"
         "- For a cog or gear, make each tooth cross the core's outside radius so it visibly protrudes; do not put a hole in the tooth profile.\n"
         "- Create holes as separate solid tools and subtract them with cut.\n"

--- a/backend/opencad_agent/tests/test_agent.py
+++ b/backend/opencad_agent/tests/test_agent.py
@@ -65,6 +65,37 @@ def test_code_generation_prompt_contains_api_guidance() -> None:
     assert "Do not use filesystem" in prompt
     assert "Valid repeated-feature composition example" in prompt
     assert "Each Sketch variable may call exactly one" in prompt
+    for primitive in ("box", "cylinder", "sphere", "cone", "torus"):
+        assert f".{primitive}(" in prompt
+    assert "A torus must use `Part(name=...).torus" in prompt
+
+
+def test_chat_executes_native_torus_primitive() -> None:
+    generated_code = (
+        "from opencad import Part, Sketch\n"
+        'result = Part(name="Torus").torus('
+        'major_radius=30, minor_radius=10, name="Torus")\n'
+    )
+    service = OpenCadAgentService(
+        live_kernel=False,
+        llm_client=LiteLlmProvider(
+            completion_func=lambda **_: {"choices": [{"message": {"content": generated_code}}]}
+        ),
+    )
+
+    response = service.chat(
+        ChatRequest(
+            message="Output a torus",
+            tree_state=_seed_tree(),
+            llm_model="test-model",
+        )
+    )
+
+    assert [operation.tool for operation in response.operations_executed] == ["create_torus"]
+    assert response.operations_executed[0].arguments == {
+        "major_radius": 30.0,
+        "minor_radius": 10.0,
+    }
 
 
 def test_chat_api_can_return_generated_code(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- replace the stale legacy operation list in the generation prompt with the fluent API reference
- advertise all native primitive methods, including cone and torus
- explicitly direct the agent to use native primitives instead of sketch/extrude approximations
- add an end-to-end regression asserting a torus request executes one `create_torus` operation

## Validation
- `python -m compileall -q backend/opencad_agent`
- `uv run pytest -q backend/opencad_agent/tests/test_agent.py backend/opencad/tests/test_fluent_api.py backend/opencad_kernel/tests/test_new_ops.py` (passed)