### PR TITLE
Fix CLI STEP exports with native OCCT geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ opencad build model.json --output model.built.json
 opencad run model.py --export output.step --tree-output output-tree.json
 ```
 
+STEP export uses the native OCCT backend. Install it with
+`uv sync --extra occt`; the CLI's default `--backend auto` mode selects it
+automatically whenever `--export` is requested. The analytic backend can be
+selected explicitly for tree-only validation with `--backend analytic`, but it
+does not produce STEP files.
+
 ## Examples
 
 The [`examples/`](examples/README.md) directory contains end-to-end scripts for common
@@ -216,7 +222,6 @@ device-development workflows:
 - `software_hmi_panel.py` — front panel for an operator interface with button and encoder cutouts
 - `firmware_programmer_fixture.py` — pogo-pin fixture plate for programming/debug access
 - `full_device_cable_grommet.py` — concentric cable grommet built from primitive booleans
-- `examples/agents/generate_mounting_bracket_code.py` — agent code-generation usage example
 
 Run an example from the repository root with:
 
@@ -230,8 +235,6 @@ The agent service generates and executes OpenCAD Python through LiteLLM for ever
 request. Provider and model can be supplied as `llm_provider` and `llm_model`, or configured
 with `OPENCAD_LLM_PROVIDER` and `OPENCAD_LLM_MODEL`. Responses include `generated_code`,
 executed operations, and the updated feature tree.
-
-For a runnable script example, see [`examples/agents/README.md`](examples/agents/README.md).
 
 ## Documentation
 

--- a/apps/backend/opencad/cli.py
+++ b/apps/backend/opencad/cli.py
@@ -5,6 +5,16 @@ import runpy
 from pathlib import Path
 
 from opencad.runtime import RuntimeContext, get_default_context, set_default_context
+from opencad_kernel.core.backend_factory import create_backend
+
+
+def _add_backend_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--backend",
+        default="auto",
+        choices=["auto", "occt", "analytic"],
+        help="Geometry backend (auto prefers OCCT; STEP export requires OCCT)",
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -21,6 +31,7 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["readable", "uuid"],
         help="Shape ID strategy for rebuild-created shapes",
     )
+    _add_backend_argument(build_parser)
     build_parser.set_defaults(func=_cmd_build)
 
     run_parser = subparsers.add_parser("run", help="Run a Python script with the opencad fluent API")
@@ -33,13 +44,15 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["readable", "uuid"],
         help="Shape ID strategy for script execution",
     )
+    _add_backend_argument(run_parser)
     run_parser.set_defaults(func=_cmd_run)
 
     return parser
 
 
 def _cmd_build(args: argparse.Namespace) -> int:
-    context = RuntimeContext(id_strategy=args.id_strategy)
+    backend = create_backend(args.backend, id_strategy=args.id_strategy)
+    context = RuntimeContext(id_strategy=args.id_strategy, backend=backend)
     context.load_tree_json(args.model)
     tree = context.rebuild_tree(continue_on_error=args.continue_on_error)
 
@@ -54,7 +67,12 @@ def _cmd_build(args: argparse.Namespace) -> int:
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
-    context = RuntimeContext(id_strategy=args.id_strategy)
+    backend = create_backend(
+        args.backend,
+        id_strategy=args.id_strategy,
+        require_native=bool(args.export),
+    )
+    context = RuntimeContext(id_strategy=args.id_strategy, backend=backend)
     set_default_context(context)
 
     script_path = Path(args.script)

--- a/apps/backend/opencad/sketch.py
+++ b/apps/backend/opencad/sketch.py
@@ -70,7 +70,7 @@ class Sketch:
         subtract: bool = False,
     ) -> Self:
         entity_id = self._new_entity_id("circle")
-        segment = SketchSegment(type="circle", center=center, radius=radius)
+        segment = SketchSegment(type="circle", center=center, radius=radius, subtract=subtract)
         self._segments.append(segment)
         self._entities[entity_id] = {
             "id": entity_id,

--- a/apps/backend/opencad/tests/test_cli.py
+++ b/apps/backend/opencad/tests/test_cli.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 from opencad import Part, Sketch, get_default_context, reset_default_context
 from opencad.cli import main
+from opencad_kernel.core.backend_factory import BackendUnavailableError
 
 
 def test_cli_build_round_trip(tmp_path: Path) -> None:
@@ -26,13 +30,23 @@ def test_cli_build_round_trip(tmp_path: Path) -> None:
 
 
 def test_cli_run_export_and_tree(tmp_path: Path) -> None:
+    if importlib.util.find_spec("cadquery") is None or importlib.util.find_spec("OCP") is None:
+        pytest.skip("CadQuery/OCP not installed")
+
+    import cadquery as cq
+
     script_path = tmp_path / "model.py"
     step_path = tmp_path / "result.step"
     tree_path = tmp_path / "result-tree.json"
     script_path.write_text(
         "from opencad import Part, Sketch\n"
-        "sk = Sketch().rect(10, 20).circle(2)\n"
-        "Part().extrude(sk, depth=5)\n",
+        "sk = (Sketch(name='Bracket Profile').rect(80, 30)\n"
+        "      .circle(3, center=(8, 8), subtract=True)\n"
+        "      .circle(3, center=(72, 8), subtract=True)\n"
+        "      .circle(3, center=(8, 22), subtract=True)\n"
+        "      .circle(3, center=(72, 22), subtract=True)\n"
+        "      .circle(5, center=(40, 15), subtract=True))\n"
+        "Part(name='Mounting Bracket').extrude(sk, depth=4).fillet(edges='top', radius=0.75)\n",
         encoding="utf-8",
     )
 
@@ -43,8 +57,61 @@ def test_cli_run_export_and_tree(tmp_path: Path) -> None:
         str(step_path),
         "--tree-output",
         str(tree_path),
+        "--backend",
+        "occt",
     ])
 
     assert code == 0
     assert step_path.exists()
+    assert tree_path.exists()
+    assert step_path.read_text(encoding="utf-8").startswith("ISO-10303-21;")
+    assert not cq.importers.importStep(str(step_path)).val().isNull()
+
+
+def test_cli_rejects_analytic_step_export(tmp_path: Path) -> None:
+    script_path = tmp_path / "model.py"
+    script_path.write_text("from opencad import Part\nPart().box(1, 1, 1)\n", encoding="utf-8")
+
+    with pytest.raises(BackendUnavailableError, match="cannot export a real STEP file"):
+        main([
+            "run",
+            str(script_path),
+            "--export",
+            str(tmp_path / "invalid.step"),
+            "--backend",
+            "analytic",
+        ])
+
+
+def test_cli_auto_step_export_requires_occt_install(tmp_path: Path) -> None:
+    if importlib.util.find_spec("cadquery") is not None and importlib.util.find_spec("OCP") is not None:
+        pytest.skip("OCCT is installed")
+
+    script_path = tmp_path / "model.py"
+    script_path.write_text("from opencad import Part\nPart().box(1, 1, 1)\n", encoding="utf-8")
+
+    with pytest.raises(BackendUnavailableError, match="CadQuery/OCP is not installed"):
+        main([
+            "run",
+            str(script_path),
+            "--export",
+            str(tmp_path / "result.step"),
+        ])
+
+
+def test_cli_tree_only_run_supports_analytic_backend(tmp_path: Path) -> None:
+    script_path = tmp_path / "model.py"
+    tree_path = tmp_path / "tree.json"
+    script_path.write_text("from opencad import Part\nPart().box(1, 1, 1)\n", encoding="utf-8")
+
+    code = main([
+        "run",
+        str(script_path),
+        "--tree-output",
+        str(tree_path),
+        "--backend",
+        "analytic",
+    ])
+
+    assert code == 0
     assert tree_path.exists()

--- a/apps/backend/opencad/tests/test_examples.py
+++ b/apps/backend/opencad/tests/test_examples.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -10,6 +11,10 @@ from opencad.cli import main
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 EXAMPLES_DIR = REPO_ROOT / "examples"
+HAS_OCCT = (
+    importlib.util.find_spec("cadquery") is not None
+    and importlib.util.find_spec("OCP") is not None
+)
 
 
 @pytest.mark.parametrize(
@@ -46,17 +51,22 @@ def test_examples_run_export_and_tree(tmp_path: Path, script_name: str, expected
     step_path = tmp_path / f"{Path(script_name).stem}.step"
     tree_path = tmp_path / f"{Path(script_name).stem}.json"
 
-    code = main([
+    arguments = [
         "run",
         str(EXAMPLES_DIR / script_name),
-        "--export",
-        str(step_path),
         "--tree-output",
         str(tree_path),
-    ])
+    ]
+    if HAS_OCCT:
+        arguments.extend(["--export", str(step_path)])
+    else:
+        arguments.extend(["--backend", "analytic"])
+
+    code = main(arguments)
 
     assert code == 0
-    assert step_path.exists()
+    if HAS_OCCT:
+        assert step_path.read_text(encoding="utf-8").startswith("ISO-10303-21;")
     assert tree_path.exists()
 
     tree = json.loads(tree_path.read_text(encoding="utf-8"))

--- a/apps/backend/opencad/tests/test_fluent_api.py
+++ b/apps/backend/opencad/tests/test_fluent_api.py
@@ -2,20 +2,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from opencad import Part, Sketch, get_default_context, reset_default_context
 
 
-def test_fluent_sketch_extrude_fillet_export(tmp_path: Path) -> None:
+def test_fluent_sketch_extrude_fillet_rejects_analytic_step_export(tmp_path: Path) -> None:
     reset_default_context()
 
     sketch = Sketch().rect(10, 20).circle(3, subtract=True)
     part = Part().extrude(sketch, depth=5).fillet(edges="top", radius=0.5)
 
     output = tmp_path / "output.step"
-    part.export(str(output))
+    with pytest.raises(RuntimeError, match="analytic backend cannot export STEP"):
+        part.export(str(output))
 
     ctx = get_default_context()
-    assert output.exists()
+    assert not output.exists()
     assert part.shape_id is not None
     assert sketch.feature_id is not None
     assert len(ctx.tree.nodes) >= 3  # root + sketch + feature chain

--- a/apps/backend/opencad_agent/tools.py
+++ b/apps/backend/opencad_agent/tools.py
@@ -122,7 +122,14 @@ class ToolRuntime:
                 cy = entity.get("cy", entity.get("y"))
                 radius = entity.get("radius")
                 if isinstance(cx, (int, float)) and isinstance(cy, (int, float)) and isinstance(radius, (int, float)):
-                    segments.append({"type": "circle", "center": (float(cx), float(cy)), "radius": float(radius)})
+                    segments.append(
+                        {
+                            "type": "circle",
+                            "center": (float(cx), float(cy)),
+                            "radius": float(radius),
+                            "subtract": bool(entity.get("subtract", False)),
+                        }
+                    )
                 continue
 
             if kind == "line":

--- a/apps/backend/opencad_kernel/api.py
+++ b/apps/backend/opencad_kernel/api.py
@@ -17,6 +17,7 @@ from starlette.background import BackgroundTask
 
 from opencad.api_app import create_api_app
 from opencad.version import __version__
+from opencad_kernel.core.backend_factory import create_backend
 from opencad_kernel.core.errors import Failure
 from opencad_kernel.core.backend import StreamingMeshBackend
 from opencad_kernel.core.models import MeshData, OperationResult, Success
@@ -32,25 +33,13 @@ router = APIRouter()
 
 # ── Backend selection ───────────────────────────────────────────────
 
-# _BACKEND_NAME = os.environ.get("OPENCAD_KERNEL_BACKEND", "analytic")
 _BACKEND_NAME = os.environ.get("OPENCAD_KERNEL_BACKEND", "occt")
 
 
 def _build_kernel() -> OpenCadKernel:
-    if _BACKEND_NAME == "occt":
-        try:
-            from opencad_kernel.core.occt_backend import OcctBackend
-        except ImportError as exc:
-            raise RuntimeError(
-                "OPENCAD_KERNEL_BACKEND=occt but CadQuery/OCP is not installed.  "
-                "Install with: uv sync --extra occt"
-            ) from exc
-        backend = OcctBackend()
-        logger.info("Kernel started with OCCT backend")
-        return OpenCadKernel(backend=backend)
-    else:
-        logger.info("Kernel started with analytic (stub) backend")
-        return OpenCadKernel()
+    backend = create_backend(_BACKEND_NAME)
+    logger.info("Kernel started with %s backend", type(backend).__name__)
+    return OpenCadKernel(backend=backend)
 
 
 app: FastAPI = create_api_app(title="OpenCAD Kernel", version=__version__)

--- a/apps/backend/opencad_kernel/core/analytic_backend.py
+++ b/apps/backend/opencad_kernel/core/analytic_backend.py
@@ -465,25 +465,12 @@ class AnalyticBackend:
         if not shape:
             return self._shape_not_found(payload.shape_id)
 
-        filepath = Path(payload.filepath)
-        payload_data = {
-            "shape_id": shape.id,
-            "kind": shape.kind,
-            "volume": shape.volume,
-            "bbox": shape.bbox.model_dump(),
-            "parameters": shape.parameters,
-        }
-        try:
-            filepath.write_text(f"OPENCAD-MOCK\n{json.dumps(payload_data)}\n", encoding="utf-8")
-        except OSError as exc:
-            return make_failure(
-                code=ErrorCode.IO_ERROR,
-                message=f"Failed to write STEP file: {exc}",
-                suggestion="Verify destination directory permissions.",
-                failed_check="step_io",
-            )
-
-        return Success(shape_id=shape.id, shape=None, metadata={"operation": "export_step", "filepath": payload.filepath})
+        return make_failure(
+            code=ErrorCode.UNSUPPORTED_STEP,
+            message="The analytic backend cannot export STEP geometry.",
+            suggestion="Use the OCCT backend and install it with: uv sync --extra occt",
+            failed_check="native_geometry_backend",
+        )
 
     def import_stl(self, payload: ImportStlInput) -> OperationResult:
         filepath = Path(payload.filepath)

--- a/apps/backend/opencad_kernel/core/backend_factory.py
+++ b/apps/backend/opencad_kernel/core/backend_factory.py
@@ -1,0 +1,65 @@
+"""Centralized geometry-backend selection.
+
+The analytic backend is useful for validation and lightweight tests, but it
+does not own native B-rep geometry.  Callers that produce exchange files must
+therefore request a native backend instead of silently accepting the analytic
+fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from opencad_kernel.core.analytic_backend import AnalyticBackend
+from opencad_kernel.core.backend import KernelBackend
+from opencad_kernel.core.store import IdStrategy
+
+BackendName = Literal["analytic", "auto", "occt"]
+
+
+class BackendUnavailableError(RuntimeError):
+    """Raised when the requested geometry backend cannot be constructed."""
+
+
+def create_backend(
+    name: BackendName | str = "auto",
+    *,
+    id_strategy: IdStrategy = "uuid",
+    require_native: bool = False,
+) -> KernelBackend:
+    """Create a geometry backend for an application entry point.
+
+    ``auto`` prefers OCCT and falls back to the analytic backend only when
+    native geometry is not required.  ``require_native`` is intended for STEP
+    and other exchange-file workflows where analytic metadata is insufficient.
+    """
+    if name not in {"analytic", "auto", "occt"}:
+        raise ValueError(f"Unknown geometry backend: {name}")
+
+    if name == "analytic":
+        if require_native:
+            raise BackendUnavailableError(
+                "The analytic backend cannot export a real STEP file. "
+                "Use --backend occt and install it with: uv sync --extra occt"
+            )
+        return AnalyticBackend(id_strategy=id_strategy)
+
+    try:
+        from opencad_kernel.core.occt_backend import HAS_OCCT, OcctBackend
+    except ImportError as exc:
+        if name == "occt" or require_native:
+            raise BackendUnavailableError(
+                "The OCCT backend is required but CadQuery/OCP is not installed. "
+                "Install it with: uv sync --extra occt"
+            ) from exc
+    else:
+        if HAS_OCCT:
+            return OcctBackend(id_strategy=id_strategy)
+
+    if name == "occt" or require_native:
+        raise BackendUnavailableError(
+            "The OCCT backend is required but CadQuery/OCP is not installed. "
+            "Install it with: uv sync --extra occt"
+        )
+
+    return AnalyticBackend(id_strategy=id_strategy)

--- a/apps/backend/opencad_kernel/core/occt_backend.py
+++ b/apps/backend/opencad_kernel/core/occt_backend.py
@@ -185,6 +185,7 @@ from opencad_kernel.operations.schemas import (
     OffsetShapeInput,
     RevolveInput,
     ShellInput,
+    SketchSegment,
     SweepInput,
 )
 
@@ -286,6 +287,51 @@ def _wire_by_index(shape: Any, index: int) -> Any:
         i += 1
         explorer.Next()
     raise IndexError(f"Wire index {index} out of range (shape has {i} wires)")
+
+
+def _sketch_edge(
+    segment: SketchSegment,
+    *,
+    plane: str,
+    origin: tuple[float, float, float],
+) -> Any | None:
+    """Build one OCCT edge without deciding how profile loops are combined."""
+    ox, oy, oz = origin
+
+    def point(coordinates: tuple[float, float]) -> Any:
+        first, second = coordinates
+        if plane == "XZ":
+            return gp_Pnt(ox + first, oy, oz + second)
+        if plane == "YZ":
+            return gp_Pnt(ox, oy + first, oz + second)
+        return gp_Pnt(ox + first, oy + second, oz)
+
+    if segment.type == "line" and segment.start and segment.end:
+        return BRepBuilderAPI_MakeEdge(point(segment.start), point(segment.end)).Edge()
+
+    if segment.type == "circle" and segment.center and segment.radius:
+        cx, cy = segment.center
+        if plane == "XZ":
+            axis = gp_Ax2(gp_Pnt(ox + cx, oy, oz + cy), gp_Dir(0, 1, 0))
+        elif plane == "YZ":
+            axis = gp_Ax2(gp_Pnt(ox, oy + cx, oz + cy), gp_Dir(1, 0, 0))
+        else:
+            axis = gp_Ax2(gp_Pnt(ox + cx, oy + cy, oz), gp_Dir(0, 0, 1))
+        return BRepBuilderAPI_MakeEdge(gp_Circ(axis, segment.radius)).Edge()
+
+    if (
+        segment.type == "arc"
+        and segment.start
+        and segment.end
+        and segment.center
+        and segment.radius
+    ):
+        cx, cy = segment.center
+        midpoint = point((cx, cy + segment.radius))
+        arc = GC_MakeArcOfCircle(point(segment.start), midpoint, point(segment.end)).Value()
+        return BRepBuilderAPI_MakeEdge(arc).Edge()
+
+    return None
 
 
 # ── Topology reference helpers ──────────────────────────────────────
@@ -1167,54 +1213,17 @@ class OcctBackend:
 
         try:
             wire_builder = BRepBuilderAPI_MakeWire()
-            ox, oy, oz = payload.origin
+            hole_builders: list[Any] = []
 
             for seg in payload.segments:
-                if seg.type == "line" and seg.start and seg.end:
-                    p1 = gp_Pnt(ox + seg.start[0], oy + seg.start[1], oz)
-                    p2 = gp_Pnt(ox + seg.end[0], oy + seg.end[1], oz)
-                    if payload.plane == "XZ":
-                        p1 = gp_Pnt(ox + seg.start[0], oy, oz + seg.start[1])
-                        p2 = gp_Pnt(ox + seg.end[0], oy, oz + seg.end[1])
-                    elif payload.plane == "YZ":
-                        p1 = gp_Pnt(ox, oy + seg.start[0], oz + seg.start[1])
-                        p2 = gp_Pnt(ox, oy + seg.end[0], oz + seg.end[1])
-                    edge = BRepBuilderAPI_MakeEdge(p1, p2).Edge()
-                    wire_builder.Add(edge)
-
-                elif seg.type == "circle" and seg.center and seg.radius:
-                    cx, cy = seg.center
-                    r = seg.radius
-                    if payload.plane == "XZ":
-                        ax = gp_Ax2(gp_Pnt(ox + cx, oy, oz + cy), gp_Dir(0, 1, 0))
-                    elif payload.plane == "YZ":
-                        ax = gp_Ax2(gp_Pnt(ox, oy + cx, oz + cy), gp_Dir(1, 0, 0))
-                    else:
-                        ax = gp_Ax2(gp_Pnt(ox + cx, oy + cy, oz), gp_Dir(0, 0, 1))
-                    circ = gp_Circ(ax, r)
-                    edge = BRepBuilderAPI_MakeEdge(circ).Edge()
-                    wire_builder.Add(edge)
-
-                elif seg.type == "arc" and seg.start and seg.end and seg.center and seg.radius:
-                    # Arc via three points: start, mid-point on arc, end
-                    cx, cy = seg.center
-                    r = seg.radius
-                    s = seg.start
-                    e = seg.end
-                    if payload.plane == "XZ":
-                        p1 = gp_Pnt(ox + s[0], oy, oz + s[1])
-                        p2 = gp_Pnt(ox + e[0], oy, oz + e[1])
-                        mid = gp_Pnt(ox + cx, oy, oz + cy + r)
-                    elif payload.plane == "YZ":
-                        p1 = gp_Pnt(ox, oy + s[0], oz + s[1])
-                        p2 = gp_Pnt(ox, oy + e[0], oz + e[1])
-                        mid = gp_Pnt(ox, oy + cx, oz + cy + r)
-                    else:
-                        p1 = gp_Pnt(ox + s[0], oy + s[1], oz)
-                        p2 = gp_Pnt(ox + e[0], oy + e[1], oz)
-                        mid = gp_Pnt(ox + cx, oy + cy + r, oz)
-                    arc = GC_MakeArcOfCircle(p1, mid, p2).Value()
-                    edge = BRepBuilderAPI_MakeEdge(arc).Edge()
+                edge = _sketch_edge(seg, plane=payload.plane, origin=payload.origin)
+                if edge is None:
+                    continue
+                if seg.subtract:
+                    hole_builder = BRepBuilderAPI_MakeWire()
+                    hole_builder.Add(edge)
+                    hole_builders.append(hole_builder)
+                else:
                     wire_builder.Add(edge)
 
             wire_builder.Build()
@@ -1226,18 +1235,43 @@ class OcctBackend:
                     failed_check="wire_build",
                 )
 
-            wire = wire_builder.Wire()
-            # Store the wire as a shape with zero volume
+            native = wire_builder.Wire()
+            if hole_builders:
+                face_builder = BRepBuilderAPI_MakeFace(native)
+                for hole_builder in hole_builders:
+                    hole_builder.Build()
+                    if not hole_builder.IsDone():
+                        return make_failure(
+                            code=ErrorCode.SKETCH_ERROR,
+                            message="Hole wire construction failed.",
+                            suggestion="Check subtractive sketch segments.",
+                            failed_check="hole_wire_build",
+                        )
+                    # Inner loops must oppose the outer loop orientation so
+                    # OCCT treats them as voids rather than additive regions.
+                    hole_wire = TopoDS.Wire_s(hole_builder.Wire().Reversed())
+                    face_builder.Add(hole_wire)
+                face_builder.Build()
+                if not face_builder.IsDone():
+                    return make_failure(
+                        code=ErrorCode.SKETCH_ERROR,
+                        message="Profile face construction failed.",
+                        suggestion="Ensure subtractive loops are closed and inside the outer profile.",
+                        failed_check="profile_face_build",
+                    )
+                native = face_builder.Face()
+
+            # Store the profile as a wire, or as a face when it contains holes.
             shape_id = self._store.new_id("sketch")
-            bbox = _bbox_from_shape(wire)
-            edge_ids = _edge_list(wire, shape_id)
+            bbox = _bbox_from_shape(native)
+            edge_ids = _edge_list(native, shape_id)
             shape = ShapeData(
                 id=shape_id, kind="sketch", parameters=payload.model_dump(),
                 bbox=bbox, volume=0.0, manifold=False,
                 edge_ids=edge_ids, face_ids=[], source_ids=[],
             )
             self._store.add(shape)
-            self._native[shape_id] = wire
+            self._native[shape_id] = native
             return self._success(shape, "create_sketch")
 
         except Exception as exc:
@@ -1260,8 +1294,11 @@ class OcctBackend:
             return self._shape_not_found(payload.sketch_id)
 
         try:
-            # Make a face from the wire, then extrude via CadQuery prism
-            face = BRepBuilderAPI_MakeFace(native).Face()
+            # Holed sketches are already faces; simple profiles remain wires.
+            if native.ShapeType() == TopAbs_FACE:
+                face = TopoDS.Face_s(native)
+            else:
+                face = BRepBuilderAPI_MakeFace(native).Face()
             vec = gp_Vec(0, 0, payload.distance)
             if payload.both:
                 vec_neg = gp_Vec(0, 0, -payload.distance)

--- a/apps/backend/opencad_kernel/operations/schemas.py
+++ b/apps/backend/opencad_kernel/operations/schemas.py
@@ -90,6 +90,7 @@ class SketchSegment(BaseModel):
     end: tuple[float, float] | None = None
     center: tuple[float, float] | None = None
     radius: float | None = None
+    subtract: bool = False
 
 
 class CreateSketchInput(BaseModel):

--- a/apps/backend/opencad_kernel/tests/test_occt_backend.py
+++ b/apps/backend/opencad_kernel/tests/test_occt_backend.py
@@ -196,6 +196,29 @@ def test_tessellate_cylinder(backend):
     assert len(mesh.faces) > 0
 
 
+def test_extrude_sketch_with_subtractive_circle(backend):
+    from math import pi
+
+    from opencad_kernel.core.models import Success
+    from opencad_kernel.operations.schemas import CreateSketchInput, ExtrudeInput, SketchSegment
+
+    segments = [
+        SketchSegment(type="line", start=(0, 0), end=(10, 0)),
+        SketchSegment(type="line", start=(10, 0), end=(10, 10)),
+        SketchSegment(type="line", start=(10, 10), end=(0, 10)),
+        SketchSegment(type="line", start=(0, 10), end=(0, 0)),
+        SketchSegment(type="circle", center=(5, 5), radius=2, subtract=True),
+    ]
+    sketch = backend.create_sketch(CreateSketchInput(segments=segments))
+    assert isinstance(sketch, Success) and sketch.shape_id
+
+    result = backend.extrude(ExtrudeInput(sketch_id=sketch.shape_id, distance=5))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    assert result.shape.volume == pytest.approx((100 - pi * 4) * 5, rel=0.01)
+
+
 def test_tessellate_missing_shape(backend):
     with pytest.raises(ValueError, match="not found"):
         backend.tessellate("nonexistent")

--- a/apps/backend/opencad_kernel/tests/test_operations.py
+++ b/apps/backend/opencad_kernel/tests/test_operations.py
@@ -234,15 +234,14 @@ def test_import_step_missing_file_fails(kernel: OpenCadKernel, tmp_path) -> None
     assert result.code == ErrorCode.IO_ERROR
 
 
-def test_export_step_success(kernel: OpenCadKernel, tmp_path) -> None:
+def test_analytic_export_step_is_rejected(kernel: OpenCadKernel, tmp_path) -> None:
     sphere = kernel.create_sphere(CreateSphereInput(radius=2.0))
     assert isinstance(sphere, Success) and sphere.shape_id
     out_path = tmp_path / "out.step"
     result = kernel.export_step(ExportStepInput(shape_id=sphere.shape_id, filepath=str(out_path)))
-    assert isinstance(result, Success)
-    assert out_path.exists()
-    text = out_path.read_text(encoding="utf-8")
-    assert text.startswith("OPENCAD-MOCK")
+    assert isinstance(result, Failure)
+    assert result.code == ErrorCode.UNSUPPORTED_STEP
+    assert not out_path.exists()
 
 
 def test_export_step_missing_shape_fails(kernel: OpenCadKernel, tmp_path) -> None:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# OpenCAD Examples
+
+These examples show how to use the in-process OpenCAD API to model parts that commonly
+appear in collaborative device-development work across hardware, software, and firmware
+teams.
+
+## Included scripts
+
+- `hardware_mounting_bracket.py` — mechanical mounting bracket with fastener holes
+- `hardware_pcb_carrier.py` — carrier plate for a controller or sensor PCB
+- `software_hmi_panel.py` — front panel for a software-driven operator interface
+- `firmware_programmer_fixture.py` — fixture plate for firmware flashing or debug access
+- `full_device_cable_grommet.py` — cable-management part built from primitive booleans
+- `simcorrect_forearm_design.py` — CAID design artifact for SimCorrect Problem 1
+
+## Running an example
+
+Install the native geometry backend and run from the repository root:
+
+```bash
+uv sync --extra occt
+python -m opencad.cli run examples/hardware_mounting_bracket.py \
+  --export bracket.step \
+  --tree-output bracket-tree.json
+```
+
+Each modeling script leaves the final part in the default runtime context, so the CLI can
+export both a STEP file and a serialized feature tree.
+
+To generate the SimCorrect Problem 1 handoff artifact:
+
+```bash
+uv run --no-sync python examples/simcorrect_forearm_design.py
+```
+
+This writes `caid-design.json` with `forearm_length` mapped to the MuJoCo parameter
+`link2_length`.

--- a/examples/firmware_programmer_fixture.py
+++ b/examples/firmware_programmer_fixture.py
@@ -1,0 +1,22 @@
+"""Firmware example: fixture plate for programming headers and alignment pins."""
+
+from opencad import Part, Sketch
+
+
+fixture_profile = (
+    Sketch(name="Programmer Fixture Profile")
+    .rect(70, 40)
+    .circle(2.5, center=(10, 10), subtract=True)
+    .circle(2.5, center=(60, 10), subtract=True)
+    .circle(2.5, center=(10, 30), subtract=True)
+    .circle(2.5, center=(60, 30), subtract=True)
+    .circle(4, center=(25, 20), subtract=True)
+    .circle(4, center=(35, 20), subtract=True)
+    .circle(4, center=(45, 20), subtract=True)
+)
+
+Part(name="Programmer Fixture").extrude(
+    fixture_profile,
+    depth=5,
+    name="Fixture Plate",
+)

--- a/examples/full_device_cable_grommet.py
+++ b/examples/full_device_cable_grommet.py
@@ -1,0 +1,9 @@
+"""Full-device example: cable grommet built from concentric cylindrical primitives."""
+
+from opencad import Part
+
+
+outer = Part(name="Outer Grommet").cylinder(14, 10, name="Outer Cylinder")
+inner = Part(name="Inner Clearance").cylinder(8, 10, name="Inner Cylinder")
+
+outer.cut(inner, name="Cable Passage")

--- a/examples/hardware_mounting_bracket.py
+++ b/examples/hardware_mounting_bracket.py
@@ -1,0 +1,20 @@
+"""Hardware example: mounting bracket with corner fasteners and a cable pass-through."""
+
+from opencad import Part, Sketch
+
+
+bracket_profile = (
+    Sketch(name="Bracket Profile")
+    .rect(80, 30)
+    .circle(3, center=(8, 8), subtract=True)
+    .circle(3, center=(72, 8), subtract=True)
+    .circle(3, center=(8, 22), subtract=True)
+    .circle(3, center=(72, 22), subtract=True)
+    .circle(5, center=(40, 15), subtract=True)
+)
+
+Part(name="Mounting Bracket").extrude(
+    bracket_profile,
+    depth=4,
+    name="Bracket Body",
+).fillet(edges="top", radius=0.75, name="Bracket Edge Relief")

--- a/examples/hardware_pcb_carrier.py
+++ b/examples/hardware_pcb_carrier.py
@@ -1,0 +1,20 @@
+"""Hardware example: PCB carrier plate with mounting holes and a clearance opening."""
+
+from opencad import Part, Sketch
+
+
+carrier_profile = (
+    Sketch(name="PCB Carrier Profile")
+    .rect(90, 60)
+    .circle(2.2, center=(8, 8), subtract=True)
+    .circle(2.2, center=(82, 8), subtract=True)
+    .circle(2.2, center=(8, 52), subtract=True)
+    .circle(2.2, center=(82, 52), subtract=True)
+    .circle(7, center=(45, 30), subtract=True)
+)
+
+Part(name="PCB Carrier").extrude(
+    carrier_profile,
+    depth=3,
+    name="Carrier Plate",
+).offset(0.4, name="Carrier Reinforcement")

--- a/examples/simcorrect_forearm_design.py
+++ b/examples/simcorrect_forearm_design.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from opencad import Part, Sketch
+
+
+def build_forearm_artifact(path: str | Path = "caid-design.json") -> Path:
+    sketch = Sketch(name="Forearm profile").rect(30, 4)
+    part = Part(name="forearm").extrude(sketch, depth=4, name="Forearm body")
+    part.export_design_artifact(
+        str(path),
+        artifact_id="simcorrect-problem1-forearm",
+        parameters={
+            "forearm_length": {
+                "value": 0.30,
+                "unit": "m",
+                "role": "geometry",
+                "feature_id": part.feature_id,
+            }
+        },
+        simulation_tags=[
+            {"name": "right_forearm", "kind": "body", "target": "r_forearm"},
+            {"name": "forearm_length", "kind": "parameter", "target": "link2_length"},
+        ],
+    )
+    return Path(path)
+
+
+if __name__ == "__main__":
+    build_forearm_artifact()

--- a/examples/software_hmi_panel.py
+++ b/examples/software_hmi_panel.py
@@ -1,0 +1,19 @@
+"""Software example: operator panel for a display, buttons, and encoder access."""
+
+from opencad import Part, Sketch
+
+
+panel_profile = (
+    Sketch(name="HMI Panel Profile")
+    .rect(120, 70)
+    .circle(6, center=(20, 18), subtract=True)
+    .circle(6, center=(40, 18), subtract=True)
+    .circle(6, center=(60, 18), subtract=True)
+    .circle(6, center=(80, 18), subtract=True)
+    .circle(6, center=(100, 18), subtract=True)
+    .circle(9, center=(104, 50), subtract=True)
+    .circle(3, center=(12, 58), subtract=True)
+    .circle(3, center=(108, 58), subtract=True)
+)
+
+Part(name="HMI Panel").extrude(panel_profile, depth=3, name="Panel Blank")


### PR DESCRIPTION
Fixes #15

## What changed
- centralize backend selection and make CLI STEP export require the native OCCT backend
- stop the analytic backend from writing `OPENCAD-MOCK` metadata under a `.step` filename
- preserve subtractive circle intent through sketch schemas and construct OCCT faces with correctly oriented hole wires
- restore the documented modeling examples, including the mounting-bracket reproduction
- validate exported STEP files by checking the ISO 10303 header and importing them back through CadQuery

## Verification
- dependency-light analytic/CLI/kernel regression set: passed (one expected OCCT skip)
- OCCT CLI + all modeling examples + subtractive-hole extrusion: 7 passed
- exact issue command: exported a 47,762-byte `ISO-10303-21` file, re-imported as a non-null CadQuery shape, and wrote the feature tree

The repository-wide suite was also exercised; unrelated existing failures remain in the live-LLM test, legacy feature-tree dependency tests, and the OCCT unique-edge-count assertion.