### PR TITLE
Separate sketches from component feature trees

### DIFF
--- a/apps/backend/opencad/part.py
+++ b/apps/backend/opencad/part.py
@@ -27,28 +27,30 @@ class Part:
         return self.feature_id, self.shape_id
 
     def _apply(
-    self,
-    operation: str,
-    payload: dict,
-    *,
-    feature_name: str,
-    parent_id: str | None = None,
-    tool_refs: list[str] | None = None,
-    tree_parameters: dict | None = None,
-    # back-compat shim during migration:
-    depends_on: list[str] | None = None,
-) -> Self:
+        self,
+        operation: str,
+        payload: dict,
+        *,
+        feature_name: str,
+        parent_id: str | None = None,
+        tool_refs: list[str] | None = None,
+        sketch_id: str | None = None,
+        tree_parameters: dict | None = None,
+        # back-compat shim during migration:
+        depends_on: list[str] | None = None,
+    ) -> Self:
         # If a caller still passes depends_on, treat first as parent, rest as tools.
         if depends_on is not None and parent_id is None and tool_refs is None:
             parent_id = depends_on[0] if depends_on else None
             tool_refs = list(depends_on[1:])
-    
+
         feature_id, shape_id = self._context.execute_operation(
             operation,
             payload,
             feature_name=feature_name,
             parent_id=parent_id,
             tool_refs=tool_refs or [],
+            sketch_id=sketch_id,
             tree_parameters=tree_parameters,
         )
         self.feature_id = feature_id
@@ -103,7 +105,7 @@ class Part:
             "extrude",
             {"sketch_id": sketch_shape_id, "distance": depth, "both": both},
             feature_name=name,
-            depends_on=[sketch.feature_id],
+            sketch_id=sketch.feature_id,
             tree_parameters={"sketch_id": sketch.feature_id, "distance": depth, "both": both},
         )
 

--- a/apps/backend/opencad/runtime.py
+++ b/apps/backend/opencad/runtime.py
@@ -79,26 +79,27 @@ class RuntimeContext:
                     self._sketch_counter = max(self._sketch_counter, int(tail) + 1)
 
     def execute_operation(
-    self,
-    operation: str,
-    payload: dict[str, Any],
-    *,
-    feature_name: str,
-    parent_id: str | None = None,
-    tool_refs: list[str] | None = None,
-    tree_parameters: dict[str, Any] | None = None,
-    feature_id: str | None = None,
-    depends_on: list[str] | None = None,  # back-compat shim
-) -> tuple[str, str]:
+        self,
+        operation: str,
+        payload: dict[str, Any],
+        *,
+        feature_name: str,
+        parent_id: str | None = None,
+        tool_refs: list[str] | None = None,
+        sketch_id: str | None = None,
+        tree_parameters: dict[str, Any] | None = None,
+        feature_id: str | None = None,
+        depends_on: list[str] | None = None,  # back-compat shim
+    ) -> tuple[str, str]:
         """Execute a kernel operation and append a built feature node."""
         # Migration shim: if a caller still passes depends_on, derive roles
         # positionally — first entry is the lineage parent, rest are tool refs.
         if depends_on is not None and parent_id is None and tool_refs is None:
             parent_id = depends_on[0] if depends_on else None
             tool_refs = list(depends_on[1:])
-    
+
         tool_refs = tool_refs or []
-    
+
         if self._external_kernel_call is not None:
             response = self._external_kernel_call(operation, payload)
         else:
@@ -121,9 +122,9 @@ class RuntimeContext:
             parameters=params,
             parent_id=parent_id,
             tool_refs=tool_refs,
+            sketch_id=node_id if operation == "create_sketch" else sketch_id,
             shape_id=str(shape_id),
             status="built",
-            sketch_id=node_id if operation == "create_sketch" else None,
         )
         self.tree = FeatureTreeService.add_feature(self.tree, node)
         self.last_feature_id = node_id

--- a/apps/backend/opencad/tests/test_fluent_api.py
+++ b/apps/backend/opencad/tests/test_fluent_api.py
@@ -22,6 +22,10 @@ def test_fluent_sketch_extrude_fillet_rejects_analytic_step_export(tmp_path: Pat
     assert part.shape_id is not None
     assert sketch.feature_id is not None
     assert len(ctx.tree.nodes) >= 3  # root + sketch + feature chain
+    extrude = next(node for node in ctx.tree.nodes.values() if node.operation == "extrude")
+    assert extrude.parent_id is None
+    assert extrude.sketch_id == sketch.feature_id
+    assert extrude.depends_on == [sketch.feature_id]
 
 
 def test_fluent_boolean_chain_records_dependencies() -> None:

--- a/apps/backend/opencad_agent/tests/test_toolruntime_live_sketch.py
+++ b/apps/backend/opencad_agent/tests/test_toolruntime_live_sketch.py
@@ -51,10 +51,14 @@ def test_live_mode_creates_sketch_shape_then_extrudes() -> None:
 
     assert tree.nodes[sketch_id].shape_id is not None
     assert str(tree.nodes[sketch_id].shape_id).startswith("sketch-")
+    assert tree.nodes[sketch_id].parent_id is None
 
     out_shape = tree.nodes[feature_id].shape_id
     assert out_shape is not None
     assert str(out_shape).startswith("extrude-")
+    assert tree.nodes[feature_id].parent_id is None
+    assert tree.nodes[feature_id].sketch_id == sketch_id
+    assert tree.nodes[feature_id].depends_on == [sketch_id]
 
 
 def test_profile_order_controls_segment_order() -> None:

--- a/apps/backend/opencad_agent/tools.py
+++ b/apps/backend/opencad_agent/tools.py
@@ -243,8 +243,6 @@ class ToolRuntime:
         profile_order: list[str] | None = None,
     ) -> str:
         sketch_id = self._new_sketch_id()
-        parent = self._latest_feature()
-        depends_on = [] if parent == self.tree.root_id else [parent]
         sketch_shape_id: str | None = None
 
         if self._use_live_kernel:
@@ -271,7 +269,6 @@ class ToolRuntime:
                 "profile_order": profile_order or [],
             },
             sketch_id=sketch_id,
-            depends_on=depends_on,
             shape_id=sketch_shape_id,
             status="built",
         )
@@ -301,7 +298,6 @@ class ToolRuntime:
             operation="extrude",
             parameters={"sketch_id": sketch_id, "depth": depth},
             sketch_id=sketch_id,
-            depends_on=[sketch_id],
             shape_id=shape_id,
             status="built",
         )
@@ -310,8 +306,6 @@ class ToolRuntime:
 
     def add_cylinder(self, position: dict[str, float], radius: float, height: float, name: str) -> str:
         feature_id = self._new_feature_id()
-        parent = self._latest_feature()
-        depends_on = [] if parent == self.tree.root_id else [parent]
         shape_id = self._new_shape_id()
 
         resolved = self._try_kernel_call("create_cylinder", {"radius": radius, "height": height})
@@ -323,7 +317,6 @@ class ToolRuntime:
             name=name,
             operation="add_cylinder",
             parameters={"position": position, "radius": radius, "height": height},
-            depends_on=depends_on,
             shape_id=shape_id,
             status="built",
         )

--- a/apps/backend/opencad_tree/models.py
+++ b/apps/backend/opencad_tree/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, model_validator
 
 NodeStatus = Literal["pending", "built", "failed", "stale", "suppressed"]
 ParameterType = Literal["int", "float", "bool", "string", "shape_ref", "json"]
@@ -31,21 +31,66 @@ class FeatureNode(BaseModel):
     typed_parameters: dict[str, TypedParameter] = Field(default_factory=dict)
     parameter_bindings: list[ParameterBinding] = Field(default_factory=list)
     sketch_id: str | None = None
-    parent_id: str | None = None                                    # NEW
-    tool_refs: list[str] = Field(default_factory=list)              # NEW
+    parent_id: str | None = None
+    tool_refs: list[str] = Field(default_factory=list)
+    depends_on: list[str] = Field(default_factory=list)
     shape_id: str | None = None
     status: NodeStatus = "pending"
     suppressed: bool = False
     mate_id: str | None = None
     is_assembly_mate: bool = False
 
-    @computed_field  # type: ignore[misc]
-    @property
-    def depends_on(self) -> list[str]:
-        """Back-compat: derived from parent_id + tool_refs."""
-        if self.parent_id is None:
-            return list(self.tool_refs)
-        return [self.parent_id, *self.tool_refs]
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_dependencies(cls, value: Any) -> Any:
+        """Keep rebuild dependencies distinct from visual body lineage.
+
+        ``sketch_id`` is a profile dependency for consuming features, never a
+        body parent. Legacy ``depends_on`` payloads are still translated into
+        the newer parent/tool roles.
+        """
+        if not isinstance(value, dict):
+            return value
+
+        data = dict(value)
+        operation = str(data.get("operation", ""))
+        node_id = data.get("id")
+        sketch_id = data.get("sketch_id")
+        owns_sketch = operation in {"sketch", "add_sketch", "create_sketch"} or sketch_id == node_id
+        profile_ref = sketch_id if isinstance(sketch_id, str) and not owns_sketch else None
+
+        dependencies = list(dict.fromkeys(data.get("depends_on") or []))
+        parent_id = data.get("parent_id")
+        tool_refs = list(data.get("tool_refs") or [])
+
+        # Migrate the old extrusion shape where the profile was incorrectly
+        # stored as the body's lineage parent/tool.
+        if profile_ref is not None:
+            if parent_id == profile_ref:
+                parent_id = None
+            tool_refs = [ref for ref in tool_refs if ref != profile_ref]
+
+        has_explicit_roles = "parent_id" in data or "tool_refs" in data
+        if not has_explicit_roles and dependencies:
+            lineage_dependencies = [ref for ref in dependencies if ref != profile_ref]
+            parent_id = lineage_dependencies[0] if lineage_dependencies else None
+            tool_refs = lineage_dependencies[1:]
+
+        normalized_dependencies = [
+            ref
+            for ref in [parent_id, *tool_refs, profile_ref]
+            if isinstance(ref, str) and ref
+        ]
+        # Preserve dependencies that do not yet have a richer role so old
+        # graph payloads and direct dependency editing remain compatible.
+        normalized_dependencies.extend(
+            ref for ref in dependencies if ref not in normalized_dependencies
+        )
+
+        data["parent_id"] = parent_id
+        data["tool_refs"] = list(dict.fromkeys(tool_refs))
+        data["depends_on"] = list(dict.fromkeys(normalized_dependencies))
+        return data
 
 
 class FeatureTree(BaseModel):

--- a/apps/backend/opencad_tree/tests/test_tree.py
+++ b/apps/backend/opencad_tree/tests/test_tree.py
@@ -98,6 +98,64 @@ def test_serialization_roundtrip() -> None:
     assert set(restored.nodes.keys()) == set(tree.nodes.keys())
 
 
+def test_sketch_reference_is_a_dependency_but_not_body_parent() -> None:
+    node = FeatureNode(
+        id="extrude",
+        name="Extrude",
+        operation="extrude",
+        sketch_id="profile",
+    )
+
+    assert node.parent_id is None
+    assert node.tool_refs == []
+    assert node.depends_on == ["profile"]
+
+
+def test_legacy_sketch_parent_is_migrated_to_profile_dependency() -> None:
+    node = FeatureNode.model_validate({
+        "id": "extrude",
+        "name": "Extrude",
+        "operation": "extrude",
+        "sketch_id": "profile",
+        "parent_id": "profile",
+        "tool_refs": [],
+        "depends_on": ["profile"],
+    })
+
+    assert node.parent_id is None
+    assert node.depends_on == ["profile"]
+
+
+def test_editing_separate_sketch_stales_consuming_component() -> None:
+    tree = FeatureTree(
+        root_id="profile",
+        nodes={
+            "profile": FeatureNode(
+                id="profile",
+                name="Profile",
+                operation="create_sketch",
+                sketch_id="profile",
+                status="built",
+                shape_id="shape-profile",
+            ),
+            "extrude": FeatureNode(
+                id="extrude",
+                name="Body",
+                operation="extrude",
+                sketch_id="profile",
+                status="built",
+                shape_id="shape-body",
+            ),
+        },
+    )
+
+    updated = FeatureTreeService.edit_feature(tree, "profile", {"segments": []})
+
+    assert updated.nodes["profile"].status == "stale"
+    assert updated.nodes["extrude"].status == "stale"
+    assert updated.nodes["extrude"].parent_id is None
+
+
 def test_delete_with_dependents_errors() -> None:
     tree = _build_12_node_tree()
     with pytest.raises(ValueError, match="dependents"):

--- a/apps/opencad_viewport/src/components/FeatureTreePanel.tsx
+++ b/apps/opencad_viewport/src/components/FeatureTreePanel.tsx
@@ -27,7 +27,7 @@ function opIcon(operation: string): string {
 }
 
 export function FeatureTreePanel({ tree, selectedNodeId, onSelectNode }: FeatureTreePanelProps): JSX.Element {
-  const { roots, childrenByParent, toolBranchesByNode } = useMemo(
+  const { roots, sketches, childrenByParent, toolBranchesByNode } = useMemo(
     () => projectFeatureTree(tree),
     [tree],
   );
@@ -122,10 +122,36 @@ export function FeatureTreePanel({ tree, selectedNodeId, onSelectNode }: Feature
     );
   };
 
+  const renderSection = (key: string, label: string, nodeIds: string[]): JSX.Element | null => {
+    if (nodeIds.length === 0) return null;
+    const sectionKey = `section:${key}`;
+    const isExpanded = expanded[sectionKey] ?? true;
+    return (
+      <div className="tree-section" key={sectionKey}>
+        <div className="tree-row tree-section-row">
+          <button
+            type="button"
+            className="tree-toggle"
+            aria-label={isExpanded ? `Collapse ${label}` : `Expand ${label}`}
+            onClick={() => toggle(sectionKey)}
+          >
+            {isExpanded ? "-" : "+"}
+          </button>
+          <span className="tree-section-label">{label}</span>
+          <span className="tree-section-count">{nodeIds.length}</span>
+        </div>
+        {isExpanded ? nodeIds.map((nodeId) => renderNode(nodeId, 1)) : null}
+      </div>
+    );
+  };
+
   return (
     <aside className="feature-tree-panel">
       <div className="panel-header">Feature Tree</div>
-      <div className="panel-body">{roots.map((nodeId) => renderNode(nodeId, 0))}</div>
+      <div className="panel-body">
+        {renderSection("components", "Components", roots)}
+        {renderSection("sketches", "Sketches", sketches)}
+      </div>
     </aside>
   );
 }

--- a/apps/opencad_viewport/src/featureTreeProjection.test.ts
+++ b/apps/opencad_viewport/src/featureTreeProjection.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import { projectFeatureTree } from "./featureTreeProjection";
 import type { FeatureNodeView, FeatureTreeView } from "./types";
 
-function node(id: string, parentId: string | null = null, toolRefs: string[] = []): FeatureNodeView {
+function node(
+  id: string,
+  parentId: string | null = null,
+  toolRefs: string[] = [],
+  overrides: Partial<FeatureNodeView> = {},
+): FeatureNodeView {
   return {
     id,
     name: id,
@@ -17,6 +22,7 @@ function node(id: string, parentId: string | null = null, toolRefs: string[] = [
     shape_id: `shape-${id}`,
     status: "built",
     suppressed: false,
+    ...overrides,
   };
 }
 
@@ -38,6 +44,7 @@ describe("feature tree projection", () => {
     ]));
 
     expect(projection.roots).toEqual(["cube"]);
+    expect(projection.sketches).toEqual([]);
     expect(projection.childrenByParent.cube).toEqual(["cut"]);
     expect(projection.toolBranchesByNode.cut).toEqual([
       { referenceId: "sphere", rootId: "sphere" },
@@ -66,5 +73,19 @@ describe("feature tree projection", () => {
     ]));
 
     expect(projection.roots).toEqual(["body"]);
+  });
+
+  it("separates sketches and promotes their consuming extrusion to a component root", () => {
+    const projection = projectFeatureTree(tree([
+      node("root", null, [], { operation: "seed", shape_id: null }),
+      node("profile", "root", [], { operation: "create_sketch", sketch_id: "profile" }),
+      node("body", "profile", [], { operation: "extrude", sketch_id: "profile" }),
+      node("fillet", "body"),
+    ]));
+
+    expect(projection.sketches).toEqual(["profile"]);
+    expect(projection.roots).toEqual(["body"]);
+    expect(projection.childrenByParent.body).toEqual(["fillet"]);
+    expect(projection.childrenByParent.profile).toEqual([]);
   });
 });

--- a/apps/opencad_viewport/src/featureTreeProjection.ts
+++ b/apps/opencad_viewport/src/featureTreeProjection.ts
@@ -1,4 +1,5 @@
 import type { FeatureTreeView } from "./types";
+import { isSketchNode } from "./sketchData";
 
 export interface ToolBranchReference {
   referenceId: string;
@@ -7,6 +8,7 @@ export interface ToolBranchReference {
 
 export interface FeatureTreeProjection {
   roots: string[];
+  sketches: string[];
   childrenByParent: Record<string, string[]>;
   toolBranchesByNode: Record<string, ToolBranchReference[]>;
 }
@@ -21,10 +23,24 @@ export function projectFeatureTree(tree: FeatureTreeView): FeatureTreeProjection
     toolBranchesByNode[nodeId] = [];
   }
 
+  const isComponentFeature = (nodeId: string): boolean => {
+    const node = tree.nodes[nodeId];
+    return Boolean(node) && !isSketchNode(node) && node.operation !== "seed";
+  };
+
+  const displayParentByNode: Record<string, string | null> = {};
   for (const [nodeId, node] of Object.entries(tree.nodes)) {
-    if (node.parent_id && tree.nodes[node.parent_id]) {
-      childrenByParent[node.parent_id].push(nodeId);
+    if (!isComponentFeature(nodeId)) continue;
+    let parentId = node.parent_id;
+    const visited = new Set<string>([nodeId]);
+    while (parentId && tree.nodes[parentId] && !visited.has(parentId)) {
+      visited.add(parentId);
+      if (isComponentFeature(parentId)) break;
+      parentId = tree.nodes[parentId].parent_id;
     }
+    const displayParent = parentId && isComponentFeature(parentId) ? parentId : null;
+    displayParentByNode[nodeId] = displayParent;
+    if (displayParent) childrenByParent[displayParent].push(nodeId);
   }
 
   const lineageRoot = (startId: string): string => {
@@ -32,8 +48,8 @@ export function projectFeatureTree(tree: FeatureTreeView): FeatureTreeProjection
     const visited = new Set<string>();
     while (!visited.has(currentId)) {
       visited.add(currentId);
-      const parentId = tree.nodes[currentId]?.parent_id;
-      if (!parentId || !tree.nodes[parentId]) return currentId;
+      const parentId = displayParentByNode[currentId];
+      if (!parentId) return currentId;
       currentId = parentId;
     }
     return startId;
@@ -41,10 +57,11 @@ export function projectFeatureTree(tree: FeatureTreeView): FeatureTreeProjection
 
   const consumedToolRoots = new Set<string>();
   for (const [nodeId, node] of Object.entries(tree.nodes)) {
+    if (!isComponentFeature(nodeId)) continue;
     const consumerRootId = lineageRoot(nodeId);
     const seenRoots = new Set<string>();
     for (const referenceId of node.tool_refs) {
-      if (!tree.nodes[referenceId]) continue;
+      if (!isComponentFeature(referenceId)) continue;
       const rootId = lineageRoot(referenceId);
       if (seenRoots.has(rootId)) continue;
       seenRoots.add(rootId);
@@ -58,11 +75,14 @@ export function projectFeatureTree(tree: FeatureTreeView): FeatureTreeProjection
     a.rootId.localeCompare(b.rootId),
   ));
 
-  const roots = Object.entries(tree.nodes)
-    .filter(([, node]) => !node.parent_id || !tree.nodes[node.parent_id])
-    .map(([nodeId]) => nodeId)
+  const roots = Object.keys(tree.nodes)
+    .filter((nodeId) => isComponentFeature(nodeId) && !displayParentByNode[nodeId])
     .filter((nodeId) => !consumedToolRoots.has(nodeId))
     .sort();
+  const sketches = Object.entries(tree.nodes)
+    .filter(([, node]) => isSketchNode(node))
+    .map(([nodeId]) => nodeId)
+    .sort();
 
-  return { roots, childrenByParent, toolBranchesByNode };
+  return { roots, sketches, childrenByParent, toolBranchesByNode };
 }

--- a/apps/opencad_viewport/src/featureVisibility.test.ts
+++ b/apps/opencad_viewport/src/featureVisibility.test.ts
@@ -80,4 +80,17 @@ describe("viewport feature visibility", () => {
     expect([...getHighlightedViewportShapeIds(screw, "head", visible)]).toEqual(["shape-relief"]);
     expect([...getHighlightedViewportShapeIds(screw, "independent", visible)]).toEqual(["shape-independent"]);
   });
+
+  it("renders the component rather than its consumed sketch mesh", () => {
+    const model = tree([
+      node("profile", null, [], { operation: "create_sketch", sketch_id: "profile" }),
+      node("body", null, [], {
+        operation: "extrude",
+        sketch_id: "profile",
+        depends_on: ["profile"],
+      }),
+    ]);
+
+    expect([...getViewportShapeIds(model)]).toEqual(["shape-body"]);
+  });
 });

--- a/apps/opencad_viewport/src/styles.css
+++ b/apps/opencad_viewport/src/styles.css
@@ -83,6 +83,35 @@ body {
   letter-spacing: 0.02em;
 }
 
+.tree-section + .tree-section {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid #e8edf4;
+}
+
+.tree-section-row {
+  color: #475569;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.tree-section-label {
+  font-size: 0.76rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tree-section-count {
+  min-width: 18px;
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #edf1f7;
+  font-size: 0.65rem;
+  text-align: center;
+}
+
 .tree-toggle {
   width: 14px;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- split the viewport feature tree into collapsible Components and Sketches sections
- keep sketch profiles as rebuild dependencies without treating them as body lineage parents
- migrate legacy extrusion nodes that stored their sketch as `parent_id`
- keep sketch edits propagating stale state to consuming components
- hide structural seed nodes and promote legacy sketch-owned extrusions to component roots

## Testing
- `OPENCAD_TREE_LIVE_KERNEL=false uv run pytest -q apps/backend/opencad_tree/tests/test_tree.py apps/backend/opencad/tests/test_fluent_api.py apps/backend/opencad_agent/tests/test_toolruntime_live_sketch.py apps/backend/opencad_agent/tests/test_agent.py`
- `pnpm test` (22 tests)
- `pnpm build`

## Existing full-suite failures
The complete repository suite still encounters four unrelated existing/environment failures: one generated-agent `.name()` call, two STEP export 422 cases, and the OCCT box edge-count expectation.