### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-08-01
 
 ### Viewport split into a publishable npm package
 
@@ -31,6 +31,15 @@ Repository-level changes: a pnpm workspace at the root (the lockfile moved
 from `apps/opencad_viewport/pnpm-lock.yaml`), the frontend Docker build now
 takes the repository root as its context, and CI builds the library, builds
 the app against it, and verifies the publishable tarball.
+
+### Release engineering
+
+- Pinned the cross-package dependencies. `opencad-agent` and `opencad-backend`
+  previously published `Requires-Dist: opencad` with no version bound, so pip
+  could pair a new agent with a core predating `adopt_tree()` and the
+  `opencad.kernel.*` layout. They now pin the exact release version.
+- All four distributions version in lockstep: `opencad`, `opencad-agent`,
+  `opencad-backend`, and the npm package `opencad-viewport`.
 
 ### Core modules nested under `opencad` (breaking)
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad-backend"
-version = "0.1.1"
+version = "0.2.0"
 description = "OpenCAD HTTP backend — FastAPI transport over the OpenCAD core and agent"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 # The only place FastAPI, httpx, and uvicorn are allowed.
 dependencies = [
-  "opencad",
-  "opencad-agent[llm]",
+  "opencad==0.2.0",
+  "opencad-agent[llm]==0.2.0",
   "fastapi>=0.100",
   "httpx>=0.27",
   "python-dotenv>=1.0",

--- a/apps/opencad_viewport/package.json
+++ b/apps/opencad_viewport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencad-viewport-app",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Reference application that hosts the OpenCAD viewport components",
   "private": true,
   "type": "module",

--- a/docs/CAID_ARTIFACT_CONTRACT.md
+++ b/docs/CAID_ARTIFACT_CONTRACT.md
@@ -17,7 +17,7 @@ Required top-level fields:
 {
   "schema_version": 1,
   "artifact_id": "simcorrect-problem1-forearm",
-  "producer": {"name": "opencad", "version": "0.1.1"},
+  "producer": {"name": "opencad", "version": "0.2.0"},
   "created_at": "2026-04-24T00:00:00Z",
   "feature_tree": {"root_id": "root", "nodes": {}},
   "parameters": {},

--- a/packages/opencad-agent/pyproject.toml
+++ b/packages/opencad-agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad-agent"
-version = "0.1.1"
+version = "0.2.0"
 description = "OpenCAD AI agent — natural-language modelling on top of the OpenCAD core"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 # Depends on the core distribution and nothing web-facing.
 dependencies = [
-  "opencad",
+  "opencad==0.2.0",
   "pydantic>=2",
 ]
 

--- a/packages/opencad-viewport/package.json
+++ b/packages/opencad-viewport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencad-viewport",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React + Three.js viewport components for OpenCAD — 3D viewport, feature tree, sketch editor, and chat panel",
   "license": "MIT",
   "repository": {

--- a/packages/opencad/pyproject.toml
+++ b/packages/opencad/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad"
-version = "0.1.1"
+version = "0.2.0"
 description = "OpenCAD core — geometry kernel, constraint solver, feature tree, and fluent modelling API"
 readme = "README.md"
 license = "MIT"

--- a/packages/opencad/src/opencad/version.py
+++ b/packages/opencad/src/opencad/version.py
@@ -1,3 +1,3 @@
 """OpenCAD package version."""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/packages/opencad/tests/runtime/test_design_artifact.py
+++ b/packages/opencad/tests/runtime/test_design_artifact.py
@@ -8,6 +8,7 @@ from opencad import (
     ParameterPatch,
     Part,
     Sketch,
+    __version__,
     apply_design_patch,
     load_design_artifact,
     reset_default_context,
@@ -40,7 +41,9 @@ def test_part_exports_caid_design_artifact(tmp_path: Path) -> None:
     artifact = load_design_artifact(output)
 
     assert artifact.schema_version == 1
-    assert artifact.producer["version"] == "0.1.1"
+    # Track the package version rather than a literal — a hardcoded string
+    # here fails on every release bump for no real coverage gain.
+    assert artifact.producer == {"name": "opencad", "version": __version__}
     assert artifact.parameters["forearm_length"].value == 0.30
     assert artifact.parameter_values() == {"forearm_length": 0.30}
     assert len(artifact.simulation_tags) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1965,7 +1965,7 @@ wheels = [
 
 [[package]]
 name = "opencad"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/opencad" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2020,7 +2020,7 @@ test = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "opencad-agent"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/opencad-agent" }
 dependencies = [
     { name = "opencad" },
@@ -2050,7 +2050,7 @@ test = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "opencad-backend"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "apps/backend" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Version bump and dependency pinning for the first tagged release. Merge this, and the tag + GitHub Release follow from the merge commit.

## Why 0.2.0 and not 0.1.1

The manifests said `0.1.1`, but `CHANGELOG.md` already records **`0.1.1 - 2026-04-24` as shipped**. Everything since sits under "Unreleased" and is breaking:

- core split into standalone distributions
- `opencad_kernel` → `opencad.kernel`
- viewport extracted into a publishable npm package
- `RuntimeContext.chat()` → `opencad_agent.run_chat()`

Tagging that `0.1.1` would put breaking changes under a version the changelog says already shipped. Under 0.x semver, breaking bumps the minor.

All four distributions move in lockstep — they're tightly coupled and every change this cycle rippled across all of them.

## The pinning fix

`opencad-agent` and `opencad-backend` were publishing unbounded dependencies:

```
Requires-Dist: opencad          ← before
Requires-Dist: opencad==0.2.0   ← after
```

`[tool.uv.sources] opencad = { workspace = true }` is dev-only metadata that **never reaches the wheel**, so the published package accepted any core version. Not theoretical: the agent calls `adopt_tree()` and imports `opencad.kernel.client`, both introduced this cycle. pip could have paired a 0.2.0 agent with an older core and produced an `AttributeError` at runtime from a resolution it considered valid.

Verified against the actual built wheels:

```
Name: opencad-agent
  Requires-Dist: opencad==0.2.0
Name: opencad-backend
  Requires-Dist: opencad==0.2.0
  Requires-Dist: opencad-agent[llm]==0.2.0
  Requires-Dist: opencad[occt]; extra == "occt"
```

`uv sync --all-packages` still resolves from the workspace locally — the source declaration takes precedence over the pin.

## One test fixed

`test_part_exports_caid_design_artifact` asserted `producer["version"] == "0.1.1"` as a literal, so it failed the moment the version moved. It now compares against `opencad.__version__` — same coverage, no per-release maintenance.

## Verification

- Python: same 5 pre-existing failures, no new ones
- Viewport: 22 tests pass, builds clean, tarball reports `0.2.0`
- Wheel metadata confirmed pinned
- `uv sync --all-packages --all-extras` succeeds with the pins in place

## After merge

```
git tag v0.2.0 <merge-commit> && git push --tags
gh release create v0.2.0 --notes-from-changelog
```

Publishing to PyPI and npm stays manual and separate — nothing here publishes anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)