### PR TITLE
docs: document the published install paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.0 - 2026-08-01
 
+Published: `opencad`, `opencad-agent`, and `opencad-backend` on PyPI.
+`opencad-viewport` is on npm at `0.1.1` — identical code, published just before
+this version bump; it will rejoin lockstep at the next release.
+
+
 ### Viewport split into a publishable npm package
 
 `apps/opencad_viewport` was a Vite application — `private: true`, no entry

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A modular CAD system for parametric, programmable, and AI-assisted design
 
+[![opencad](https://img.shields.io/pypi/v/opencad?label=opencad)](https://pypi.org/project/opencad/)
+[![opencad-agent](https://img.shields.io/pypi/v/opencad-agent?label=opencad-agent)](https://pypi.org/project/opencad-agent/)
+[![opencad-backend](https://img.shields.io/pypi/v/opencad-backend?label=opencad-backend)](https://pypi.org/project/opencad-backend/)
+[![Python](https://img.shields.io/pypi/pyversions/opencad)](https://pypi.org/project/opencad/)
+[![opencad-viewport](https://img.shields.io/npm/v/opencad-viewport?label=opencad-viewport&logo=npm)](https://www.npmjs.com/package/opencad-viewport)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+
 ## Components
 
 - `opencad.kernel` — geometry kernel and typed operation registry
@@ -47,13 +54,37 @@ the backend fails the build.
 
 ### 1. Install
 
-For a packaged install, pick the layer you need — each is independent:
+Published on PyPI. Pick the layer you need — each installs independently, and
+each pulls the ones below it:
 
 ```bash
-uv pip install "opencad[occt]"        # core only: kernel, solver, tree, fluent API
-uv pip install "opencad-agent[llm]"   # + natural-language modelling
-uv pip install opencad-backend        # + the FastAPI HTTP service
+pip install opencad                   # core: kernel, solver, tree, fluent API, CLI
+pip install "opencad[occt]"           #   + OCCT B-rep backend (real STEP/STL)
+pip install "opencad-agent[llm]"      #   + natural-language modelling
+pip install opencad-backend           #   + the FastAPI HTTP service
 ```
+
+Installing `opencad` alone gets you a working kernel with **no web framework in
+the environment** — no FastAPI, no httpx. That is the point of the split:
+
+```python
+from opencad import Part, Sketch
+
+plate = Part().extrude(Sketch().rect(80, 30), depth=4)
+plate.fillet(edges="all", radius=1.0)
+```
+
+Cross-package versions move in lockstep and are pinned exactly, so
+`opencad-agent 0.2.0` can only resolve against `opencad 0.2.0`.
+
+The React components ship separately on npm:
+
+```bash
+npm install opencad-viewport react react-dom three @react-three/fiber @react-three/drei
+```
+
+React, Three.js, and the react-three packages are peer dependencies — they are
+singleton-sensitive, so the library never bundles them.
 
 For local development from this repository:
 


### PR DESCRIPTION
The install section was written before anything was published, so it read as aspirational. All four packages are now live.

## Changes

- Registry badges for `opencad`, `opencad-agent`, `opencad-backend` (PyPI) and `opencad-viewport` (npm)
- Real `pip install` commands, layered so it's clear what each level adds
- The `npm install` line for the React components, with the peer-dependency note
- A short example showing `pip install opencad` gives a working kernel with no web framework in the environment

Every documented command was verified to resolve against the live indexes before writing it down:

```
opencad[occt]          resolves
opencad-agent[llm]     resolves
opencad-backend        resolves
```

## One discrepancy recorded

`opencad-viewport` is on npm at **0.1.1**, not 0.2.0 — it was published at 21:38, minutes before the version bump landed. I diffed it: the only difference between the published tree and `v0.2.0` is the version string itself, so the code is identical and nothing is broken. Noted in the changelog; it rejoins lockstep at the next release.

If you'd rather have the registries agree now, publishing `0.2.0` to npm from the tag is enough — no code change needed.

## Note on direct push

`main` is a protected branch, so this comes as a PR rather than a direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)