### PR TITLE
fix: correct the README license badge and the broken python badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A modular CAD system for parametric, programmable, and AI-assisted design
 [![opencad](https://img.shields.io/pypi/v/opencad?label=opencad)](https://pypi.org/project/opencad/)
 [![opencad-agent](https://img.shields.io/pypi/v/opencad-agent?label=opencad-agent)](https://pypi.org/project/opencad-agent/)
 [![opencad-backend](https://img.shields.io/pypi/v/opencad-backend?label=opencad-backend)](https://pypi.org/project/opencad-backend/)
-[![Python](https://img.shields.io/pypi/pyversions/opencad)](https://pypi.org/project/opencad/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://pypi.org/project/opencad/)
 [![opencad-viewport](https://img.shields.io/npm/v/opencad-viewport?label=opencad-viewport&logo=npm)](https://www.npmjs.com/package/opencad-viewport)
-[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 ## Components
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -10,6 +10,19 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Manufacturing",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Multimedia :: Graphics :: 3D Modeling",
+]
 # The only place FastAPI, httpx, and uvicorn are allowed.
 dependencies = [
   "opencad==0.2.1",

--- a/packages/opencad-agent/pyproject.toml
+++ b/packages/opencad-agent/pyproject.toml
@@ -10,6 +10,19 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Manufacturing",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Multimedia :: Graphics :: 3D Modeling",
+]
 # Depends on the core distribution and nothing web-facing.
 dependencies = [
   "opencad==0.2.1",

--- a/packages/opencad-agent/pyproject.toml
+++ b/packages/opencad-agent/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/packages/opencad/pyproject.toml
+++ b/packages/opencad/pyproject.toml
@@ -10,6 +10,19 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Manufacturing",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Multimedia :: Graphics :: 3D Modeling",
+]
 # Core only. No web framework, no HTTP client — see
 # apps/backend/tests/test_core_boundary.py.
 dependencies = [

--- a/packages/opencad/pyproject.toml
+++ b/packages/opencad/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Two broken badges on `main`.

**License read MIT.** My Apache-2.0 correction went onto the docs branch after #75 had already merged, so it never reached `main`. Now static Apache-2.0.

**Python read "missing".** `shields.io/pypi/pyversions` reads trove classifiers, and none of the packages declared any. Swapped for a static `3.10+` badge matching `requires-python`, and added the missing classifiers so PyPI metadata is correct as well.

Verified all badge URLs return HTTP 200. The version badges showing `0.2.0` in your screenshot were shields.io cache — they now resolve to `v0.2.1`.

Classifiers take effect on PyPI at the next release; the static badge is correct immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)