### PR TITLE
fix: extrude along the sketch plane normal instead of always Z

### DIFF
--- a/packages/opencad/src/opencad/kernel/core/occt_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/occt_backend.py
@@ -335,6 +335,21 @@ def _sketch_edge(
     return None
 
 
+# Sketch planes name the two axes they span, so the extrusion axis is the one
+# they leave out. Kept next to _sketch_edge so the plane mapping and its normal
+# cannot drift apart.
+_PLANE_NORMALS: dict[str, tuple[float, float, float]] = {
+    "XY": (0.0, 0.0, 1.0),
+    "XZ": (0.0, 1.0, 0.0),
+    "YZ": (1.0, 0.0, 0.0),
+}
+
+
+def _plane_normal(plane: str | None) -> tuple[float, float, float]:
+    """Unit normal of a sketch plane. Unknown names fall back to XY."""
+    return _PLANE_NORMALS.get(str(plane or "XY").upper(), _PLANE_NORMALS["XY"])
+
+
 # ── Topology reference helpers ──────────────────────────────────────
 
 
@@ -1406,9 +1421,16 @@ class OcctBackend:
                 face = TopoDS.Face_s(native)
             else:
                 face = BRepBuilderAPI_MakeFace(native).Face()
-            vec = gp_Vec(0, 0, payload.distance)
+            # Raise along the sketch plane's normal. Extruding a non-XY sketch
+            # along Z would sweep the profile within its own plane and produce a
+            # zero-volume shape that still looks like a success.
+            dx, dy, dz = (
+                component * payload.distance
+                for component in _plane_normal(meta.parameters.get("plane"))
+            )
+            vec = gp_Vec(dx, dy, dz)
             if payload.both:
-                vec_neg = gp_Vec(0, 0, -payload.distance)
+                vec_neg = gp_Vec(-dx, -dy, -dz)
                 prism_mod = importlib.import_module("OCP.BRepPrimAPI")
                 solid_pos = prism_mod.BRepPrimAPI_MakePrism(face, vec).Shape()
                 solid_neg = prism_mod.BRepPrimAPI_MakePrism(face, vec_neg).Shape()

--- a/packages/opencad/tests/kernel/test_occt_backend.py
+++ b/packages/opencad/tests/kernel/test_occt_backend.py
@@ -246,6 +246,64 @@ def test_extrude_sketch_with_subtractive_circle(backend):
     assert result.shape.volume == pytest.approx((100 - pi * 4) * 5, rel=0.01)
 
 
+def _rect_segments(width: float, height: float) -> list:
+    from opencad.kernel.operations.schemas import SketchSegment
+
+    return [
+        SketchSegment(type="line", start=(0, 0), end=(width, 0)),
+        SketchSegment(type="line", start=(width, 0), end=(width, height)),
+        SketchSegment(type="line", start=(width, height), end=(0, height)),
+        SketchSegment(type="line", start=(0, height), end=(0, 0)),
+    ]
+
+
+@pytest.mark.parametrize(("plane", "normal_axis"), [("XY", "z"), ("XZ", "y"), ("YZ", "x")])
+def test_extrude_raises_along_the_sketch_plane_normal(backend, plane, normal_axis):
+    """Extruding along Z regardless of plane swept XZ/YZ profiles within their
+    own plane, yielding a zero-volume shape that still reported success."""
+    from opencad.kernel.core.models import Success
+    from opencad.kernel.operations.schemas import CreateSketchInput, ExtrudeInput
+
+    sketch = backend.create_sketch(
+        CreateSketchInput(plane=plane, segments=_rect_segments(20, 10))
+    )
+    assert isinstance(sketch, Success) and sketch.shape_id
+
+    result = backend.extrude(ExtrudeInput(sketch_id=sketch.shape_id, distance=5))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    assert result.shape.volume == pytest.approx(20 * 10 * 5, rel=0.01)
+
+    bbox = result.shape.bbox
+    spans = {
+        "x": bbox.max_x - bbox.min_x,
+        "y": bbox.max_y - bbox.min_y,
+        "z": bbox.max_z - bbox.min_z,
+    }
+    assert spans[normal_axis] == pytest.approx(5, rel=0.01)
+
+
+def test_extrude_both_straddles_a_non_xy_sketch(backend):
+    from opencad.kernel.core.models import Success
+    from opencad.kernel.operations.schemas import CreateSketchInput, ExtrudeInput
+
+    sketch = backend.create_sketch(
+        CreateSketchInput(plane="XZ", segments=_rect_segments(20, 10))
+    )
+    assert isinstance(sketch, Success) and sketch.shape_id
+
+    result = backend.extrude(
+        ExtrudeInput(sketch_id=sketch.shape_id, distance=5, both=True)
+    )
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    assert result.shape.volume == pytest.approx(20 * 10 * 10, rel=0.01)
+    assert result.shape.bbox.min_y == pytest.approx(-5, abs=0.01)
+    assert result.shape.bbox.max_y == pytest.approx(5, abs=0.01)
+
+
 def test_tessellate_missing_shape(backend):
     with pytest.raises(ValueError, match="not found"):
         backend.tessellate("nonexistent")


### PR DESCRIPTION
## Problem

`OcctBackend.extrude` built its prism vector as `gp_Vec(0, 0, distance)` regardless of which plane the sketch was drawn on. For an `XZ` or `YZ` sketch that direction lies *inside* the profile's own plane, so the sweep collapses.

The failure is silent. The operation returns `ok=True`, the shape reports `valid=True`, and the volume is exactly zero:

```python
for plane in ("XY", "XZ", "YZ"):
    p = Part(name=plane).extrude(Sketch(plane=plane).rect(20.0, 10.0), depth=5.0)
    print(plane, cq.Shape(get_native(p.shape_id)).Volume())

# XY -> 1000.000
# XZ ->    0.000   <- silently empty, still ok=True / valid=True
# YZ ->    0.000
```

Nothing surfaces this, so a model can be built, validated, and exported as an empty solid.

## Fix

Derive the direction from the plane already recorded on the profile's `ShapeData.parameters`. The extrusion axis is the one the plane name omits, so `XY` raises along Z, `XZ` along Y, `YZ` along X. `_plane_normal` sits next to `_sketch_edge` so the plane→3D mapping and its normal can't drift apart.

- `XY` behaviour is unchanged (its normal is still +Z), so this is backward compatible for every sketch that worked before.
- `both=True` now straddles the sketch plane rather than always straddling XY.
- Unknown plane names fall back to XY, matching the existing default in `CreateSketchInput`.

## Convention note

I used the **positive** omitted axis (`XZ` → +Y). The strictly right-handed normal for the `XZ` mapping in `_sketch_edge` (`u`→X, `v`→Z) would be **-Y**, since X × Z = -Y. Positive felt less surprising and negative `distance` still reaches the other side, but happy to flip it if you'd rather the frame stay right-handed.

## Tests

Added to `tests/kernel/test_occt_backend.py`:

- `test_extrude_raises_along_the_sketch_plane_normal` — parametrized over all three planes, asserting the correct volume and that the bbox grows along the expected axis.
- `test_extrude_both_straddles_a_non_xy_sketch` — `both=True` on an XZ sketch spans -5..+5 in Y.

`227 passed, 1 failed, 1 skipped`. The one failure is `test_create_box`, which is pre-existing on `main` and unrelated — a box enumerates 24 edge IDs instead of 12. I've sent that separately.

## Context

Found while modelling a threaded bottle through the fluent API, where the natural way to draw a revolve profile is on `XZ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)