### PR TITLE
fix: make sketch arcs build correctly and reachable from Sketch

### DIFF
--- a/packages/opencad/src/opencad/kernel/core/occt_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/occt_backend.py
@@ -298,6 +298,28 @@ def _wire_by_index(shape: Any, index: int) -> Any:
     raise IndexError(f"Wire index {index} out of range (shape has {i} wires)")
 
 
+def _arc_midpoint(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    center: tuple[float, float],
+    radius: float,
+) -> tuple[float, float]:
+    """Point halfway along the counter-clockwise arc from *start* to *end*.
+
+    GC_MakeArcOfCircle is a three-point constructor, so it needs a point that
+    actually lies between the endpoints. Sweeping counter-clockwise matches the
+    convention used for arcs elsewhere in CAD interchange (DXF, SVG's sweep
+    flag), and a clockwise arc is expressed by swapping the endpoints.
+    """
+    cx, cy = center
+    start_angle = math.atan2(start[1] - cy, start[0] - cx)
+    end_angle = math.atan2(end[1] - cy, end[0] - cx)
+    if end_angle <= start_angle:
+        end_angle += 2.0 * math.pi
+    mid_angle = start_angle + (end_angle - start_angle) / 2.0
+    return (cx + radius * math.cos(mid_angle), cy + radius * math.sin(mid_angle))
+
+
 def _sketch_edge(
     segment: SketchSegment,
     *,
@@ -335,9 +357,12 @@ def _sketch_edge(
         and segment.center
         and segment.radius
     ):
-        cx, cy = segment.center
-        midpoint = point((cx, cy + segment.radius))
-        arc = GC_MakeArcOfCircle(point(segment.start), midpoint, point(segment.end)).Value()
+        midpoint = _arc_midpoint(
+            segment.start, segment.end, segment.center, segment.radius
+        )
+        arc = GC_MakeArcOfCircle(
+            point(segment.start), point(midpoint), point(segment.end)
+        ).Value()
         return BRepBuilderAPI_MakeEdge(arc).Edge()
 
     return None

--- a/packages/opencad/src/opencad/sketch.py
+++ b/packages/opencad/src/opencad/sketch.py
@@ -62,6 +62,34 @@ class Sketch:
         self.line(p4, p1)
         return self
 
+    def arc(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        *,
+        center: tuple[float, float],
+        radius: float,
+    ) -> Self:
+        """Add the counter-clockwise arc from *start* to *end* about *center*.
+
+        Swapping the endpoints gives the clockwise arc, which is also how to ask
+        for the major arc between the same two points.
+        """
+        entity_id = self._new_entity_id("arc")
+        self._segments.append(
+            SketchSegment(type="arc", start=start, end=end, center=center, radius=radius)
+        )
+        self._entities[entity_id] = {
+            "id": entity_id,
+            "type": "arc",
+            "start": start,
+            "end": end,
+            "center": center,
+            "radius": radius,
+        }
+        self._profile_order.append(entity_id)
+        return self
+
     def circle(
         self,
         radius: float,

--- a/packages/opencad/tests/kernel/test_occt_backend.py
+++ b/packages/opencad/tests/kernel/test_occt_backend.py
@@ -357,6 +357,68 @@ def test_extrude_both_straddles_a_non_xy_sketch(backend):
     assert result.shape.bbox.max_y == pytest.approx(5, abs=0.01)
 
 
+# ── Sketch arcs ─────────────────────────────────────────────────────
+
+
+def _arc_sketch(backend, start, end, radius=10.0):
+    from opencad.kernel.operations.schemas import CreateSketchInput, SketchSegment
+
+    return backend.create_sketch(
+        CreateSketchInput(
+            segments=[
+                SketchSegment(
+                    type="arc", start=start, end=end, center=(0.0, 0.0), radius=radius
+                )
+            ]
+        )
+    )
+
+
+def test_sketch_arc_spans_only_its_own_quadrant(backend):
+    """The interior point was assumed to sit at (cx, cy + radius). For a quarter
+    arc starting there that collapsed onto an endpoint and GC_MakeArcOfCircle
+    raised 'no result', so any arc not apexed straight above the centre failed."""
+    from opencad.kernel.core.models import Success
+
+    result = _arc_sketch(backend, (10.0, 0.0), (0.0, 10.0))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    bbox = result.shape.bbox
+    assert bbox.min_x == pytest.approx(0.0, abs=0.01)
+    assert bbox.max_x == pytest.approx(10.0, abs=0.01)
+    assert bbox.min_y == pytest.approx(0.0, abs=0.01)
+    assert bbox.max_y == pytest.approx(10.0, abs=0.01)
+
+
+def test_sketch_arc_sweeps_counter_clockwise(backend):
+    """Swapping the endpoints takes the long way round, which is how a caller
+    asks for the major arc."""
+    from opencad.kernel.core.models import Success
+
+    result = _arc_sketch(backend, (0.0, 10.0), (10.0, 0.0))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    bbox = result.shape.bbox
+    assert bbox.min_x == pytest.approx(-10.0, abs=0.01)
+    assert bbox.min_y == pytest.approx(-10.0, abs=0.01)
+
+
+def test_sketch_arc_semicircle(backend):
+    from opencad.kernel.core.models import Success
+
+    result = _arc_sketch(backend, (10.0, 0.0), (-10.0, 0.0))
+
+    assert isinstance(result, Success)
+    assert result.shape is not None
+    bbox = result.shape.bbox
+    assert bbox.min_x == pytest.approx(-10.0, abs=0.01)
+    assert bbox.max_x == pytest.approx(10.0, abs=0.01)
+    assert bbox.min_y == pytest.approx(0.0, abs=0.01)
+    assert bbox.max_y == pytest.approx(10.0, abs=0.01)
+
+
 def test_tessellate_missing_shape(backend):
     with pytest.raises(ValueError, match="not found"):
         backend.tessellate("nonexistent")

--- a/packages/opencad/tests/runtime/test_fluent_api.py
+++ b/packages/opencad/tests/runtime/test_fluent_api.py
@@ -160,3 +160,55 @@ def test_fluent_revolve_builds_a_real_annulus() -> None:
         assert cq.Shape(native).Volume() == pytest.approx(expected, rel=0.001)
     finally:
         reset_default_context()
+
+
+# ── Sketch arcs ─────────────────────────────────────────────────────
+
+
+def test_fluent_sketch_records_an_arc_entity() -> None:
+    reset_default_context()
+    sketch = (
+        Sketch(name="Half disc")
+        .line((-10.0, 0.0), (10.0, 0.0))
+        .arc((10.0, 0.0), (-10.0, 0.0), center=(0.0, 0.0), radius=10.0)
+    )
+    Part().extrude(sketch, depth=5)
+
+    ctx = get_default_context()
+    assert sketch.feature_id is not None
+    entities = ctx.tree.nodes[sketch.feature_id].parameters.get("entities", {})
+
+    arcs = [entity for entity in entities.values() if entity.get("type") == "arc"]
+    assert len(arcs) == 1
+    assert arcs[0]["center"] == (0.0, 0.0)
+    assert arcs[0]["radius"] == 10.0
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("OCP") is None, reason="CadQuery/OCP not installed"
+)
+def test_fluent_arc_closes_a_half_disc_profile() -> None:
+    """A diameter plus its arc is the smallest closed profile that needs an arc,
+    so the extruded volume pins down that the arc bows the right way."""
+    import cadquery as cq
+
+    from opencad.kernel.core.backend_factory import create_backend
+    from opencad.runtime import RuntimeContext, set_default_context
+
+    ctx = RuntimeContext(backend=create_backend("occt", require_native=True))
+    set_default_context(ctx)
+    try:
+        radius, depth = 10.0, 5.0
+        sketch = (
+            Sketch(name="Half disc")
+            .line((-radius, 0.0), (radius, 0.0))
+            .arc((radius, 0.0), (-radius, 0.0), center=(0.0, 0.0), radius=radius)
+        )
+        part = Part().extrude(sketch, depth=depth)
+
+        assert part.shape_id is not None
+        native = ctx.registry.kernel.get_native_shape(part.shape_id)
+        expected = math.pi * radius**2 / 2.0 * depth
+        assert cq.Shape(native).Volume() == pytest.approx(expected, rel=0.001)
+    finally:
+        reset_default_context()


### PR DESCRIPTION
## Problem

`_sketch_edge` builds arcs with `GC_MakeArcOfCircle`, a three-point constructor, and passed an interior point hardcoded to `(cx, cy + radius)` — directly above the centre, regardless of where the arc actually runs:

```python
cx, cy = segment.center
midpoint = point((cx, cy + segment.radius))
```

That point only lies between the endpoints for arcs apexed straight up. Anywhere else it either bends the arc the wrong way, or — when the assumed point coincides with an endpoint — makes the constructor degenerate. A quarter arc is enough to trigger it:

```python
backend.create_sketch(CreateSketchInput(segments=[
    SketchSegment(type="arc", start=(0.0, 10.0), end=(10.0, 0.0),
                  center=(0.0, 0.0), radius=10.0),
]))
# ok=False — "Sketch creation failed: GC_MakeArcOfCircle::Value() - no result"
```

Separately, `Sketch` exposed only `line`, `rect`, and `circle`. `SketchSegment` has carried an `"arc"` type all along and the backend builds the edge, but no fluent caller could produce one — so arcs were unreachable as well as broken.

## Changes

**1. Compute the real midpoint** by bisecting the angle from start to end. The sweep goes **counter-clockwise**, matching the convention in DXF and SVG's sweep flag; a clockwise arc is expressed by swapping the endpoints, which also gives callers a way to request the major arc.

**2. Add `Sketch.arc(start, end, *, center, radius)`**, mirroring the entity bookkeeping `line` and `circle` already do so an arc lands in `profile_order` and the feature tree the same way.

I've kept these together because the fix and the accessor are only useful as a pair — shipping either alone still leaves arcs unusable.

## Verified

| start → end | before | after (bbox) |
|---|---|---|
| `(10,0) → (0,10)` | raises | `X 0..10, Y 0..10` (minor arc) |
| `(0,10) → (10,0)` | raises | `X -10..10, Y -10..10` (major arc) |
| `(10,0) → (-10,0)` | ok, by luck | `X -10..10, Y 0..10` (semicircle) |

The semicircle is the one case the old code got right — its apex genuinely is at `(cx, cy + radius)` — so this is backward compatible for arcs that already worked.

## Tests

Kernel (`tests/kernel/test_occt_backend.py`): minor arc, the counter-clockwise convention via the major arc, and the semicircle regression.

Fluent (`tests/runtime/test_fluent_api.py`): the arc entity reaches the tree, and — OCCT-guarded — a diameter plus its arc extrudes to a half-disc whose volume matches `πr²/2 · d` to 0.1%, which pins down that the arc bows the correct way rather than merely building.

`228 passed, 1 failed, 1 skipped`. The failure is `test_create_box`, pre-existing on `main` and unrelated (24 edge IDs for a box instead of 12) — fixed separately in #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
