### PR TITLE
fix: count each edge once when enumerating topology

### DIFF
--- a/packages/opencad/src/opencad/kernel/core/occt_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/occt_backend.py
@@ -69,14 +69,16 @@ TopAbs_EDGE = None
 TopAbs_FACE = None
 TopAbs_WIRE = None
 TopAbs_REVERSED = None
+TopExp = None
 TopExp_Explorer = None
 TopLoc_Location = None
 TopoDS = None
 TopoDS_Shape = Any
 StlAPI_Reader = None
 
-# Lists
+# Lists / maps
 TopTools_ListOfShape = None
+TopTools_IndexedMapOfShape = None
 
 if HAS_OCCT:  # pragma: no branch
     cq = importlib.import_module("cadquery")
@@ -137,7 +139,9 @@ if HAS_OCCT:  # pragma: no branch
     TopAbs_WIRE = topabs_mod.TopAbs_WIRE
     TopAbs_REVERSED = topabs_mod.TopAbs_REVERSED
 
-    TopExp_Explorer = importlib.import_module("OCP.TopExp").TopExp_Explorer
+    topexp_mod = importlib.import_module("OCP.TopExp")
+    TopExp = topexp_mod.TopExp
+    TopExp_Explorer = topexp_mod.TopExp_Explorer
     TopLoc_Location = importlib.import_module("OCP.TopLoc").TopLoc_Location
 
     topods_mod = importlib.import_module("OCP.TopoDS")
@@ -146,7 +150,9 @@ if HAS_OCCT:  # pragma: no branch
 
     StlAPI_Reader = importlib.import_module("OCP.StlAPI").StlAPI_Reader
 
-    TopTools_ListOfShape = importlib.import_module("OCP.TopTools").TopTools_ListOfShape
+    toptools_mod = importlib.import_module("OCP.TopTools")
+    TopTools_ListOfShape = toptools_mod.TopTools_ListOfShape
+    TopTools_IndexedMapOfShape = toptools_mod.TopTools_IndexedMapOfShape
 
 from opencad.kernel.core.checks import check_bbox_overlap, check_manifold, check_nonzero_volume
 from opencad.kernel.core.errors import ErrorCode, make_failure
@@ -230,28 +236,30 @@ def _is_manifold(shape: Any) -> bool:
     return analyzer.IsValid()
 
 
+def _edges_from_shape(shape: Any) -> list[Any]:
+    """Return each edge once, in stable first-encountered order.
+
+    An edge is shared by the faces that meet along it, and TopExp_Explorer
+    yields it once per face, so walking it directly reports a box's 12 edges
+    24 times. MapShapes indexes on shape identity, which collapses those
+    repeats while keeping traversal order.
+    """
+    edge_map = TopTools_IndexedMapOfShape()
+    TopExp.MapShapes_s(shape, TopAbs_EDGE, edge_map)
+    return [TopoDS.Edge_s(edge_map.FindKey(i)) for i in range(1, edge_map.Extent() + 1)]
+
+
 def _edge_list(shape: Any, shape_id: str) -> list[str]:
     """Enumerate edges and return deterministic IDs."""
-    ids: list[str] = []
-    explorer = TopExp_Explorer(shape, TopAbs_EDGE)
-    idx = 0
-    while explorer.More():
-        ids.append(f"{shape_id}:edge:{idx}")
-        idx += 1
-        explorer.Next()
-    return ids
+    return [f"{shape_id}:edge:{idx}" for idx in range(len(_edges_from_shape(shape)))]
 
 
 def _edge_by_index(shape: Any, index: int) -> Any:
     """Return the TopoDS_Edge at *index* for fillet operations."""
-    explorer = TopExp_Explorer(shape, TopAbs_EDGE)
-    i = 0
-    while explorer.More():
-        if i == index:
-            return TopoDS.Edge_s(explorer.Current())
-        i += 1
-        explorer.Next()
-    raise IndexError(f"Edge index {index} out of range (shape has {i} edges)")
+    edges = _edges_from_shape(shape)
+    if not 0 <= index < len(edges):
+        raise IndexError(f"Edge index {index} out of range (shape has {len(edges)} edges)")
+    return edges[index]
 
 
 def _face_list(shape: Any, shape_id: str) -> list[str]:
@@ -426,10 +434,7 @@ def _build_topology_map(shape: Any, shape_id: str) -> TopologyMap:
         explorer.Next()
 
     edge_refs: list[SubshapeRef] = []
-    explorer = TopExp_Explorer(shape, TopAbs_EDGE)
-    idx = 0
-    while explorer.More():
-        edge = TopoDS.Edge_s(explorer.Current())
+    for idx, edge in enumerate(_edges_from_shape(shape)):
         centroid = _edge_centroid(edge)
         length = _edge_length(edge)
         edge_refs.append(SubshapeRef(
@@ -440,8 +445,6 @@ def _build_topology_map(shape: Any, shape_id: str) -> TopologyMap:
             length=length,
             tags=[],
         ))
-        idx += 1
-        explorer.Next()
 
     return TopologyMap(shape_id=shape_id, faces=face_refs, edges=edge_refs)
 

--- a/packages/opencad/tests/kernel/test_occt_backend.py
+++ b/packages/opencad/tests/kernel/test_occt_backend.py
@@ -39,6 +39,59 @@ def test_create_box(backend):
     assert len(result.shape.edge_ids) == 12  # A box has 12 edges
 
 
+def test_primitive_edges_are_counted_once_each(backend):
+    """Edges are shared between adjacent faces and TopExp_Explorer yields one
+    per face, so enumeration used to report a box's 12 edges as 24."""
+    from opencad.kernel.core.models import Success
+    from opencad.kernel.operations.schemas import (
+        CreateBoxInput,
+        CreateCylinderInput,
+        CreateSphereInput,
+    )
+
+    box = backend.create_box(CreateBoxInput(length=10.0, width=5.0, height=3.0))
+    cylinder = backend.create_cylinder(CreateCylinderInput(radius=2.0, height=5.0))
+    sphere = backend.create_sphere(CreateSphereInput(radius=3.0))
+    assert all(isinstance(r, Success) and r.shape for r in (box, cylinder, sphere))
+
+    # A box has 12 edges, an OCCT cylinder 3 (two rims and a seam), a sphere 3.
+    assert len(box.shape.edge_ids) == 12
+    assert len(cylinder.shape.edge_ids) == 3
+    assert len(sphere.shape.edge_ids) == 3
+
+
+def test_edge_ids_are_unique_and_match_the_topology_map(backend):
+    """shape.edge_ids and get_topology() must agree, since selectors resolve
+    against the topology map and then index back into the shape."""
+    from opencad.kernel.core.models import Success
+    from opencad.kernel.operations.schemas import CreateBoxInput
+
+    box = backend.create_box(CreateBoxInput(length=10.0, width=5.0, height=3.0))
+    assert isinstance(box, Success) and box.shape is not None
+
+    edge_ids = box.shape.edge_ids
+    assert len(set(edge_ids)) == len(edge_ids)
+
+    topology = backend.get_topology(box.shape_id)
+    assert [edge.id for edge in topology.edges] == edge_ids
+
+
+def test_every_enumerated_edge_is_filletable(backend):
+    """A duplicated enumeration made 'all edges' pass the same edge twice and
+    left later indices unreachable."""
+    from opencad.kernel.core.models import Success
+    from opencad.kernel.operations.schemas import CreateBoxInput, FilletEdgesInput
+
+    box = backend.create_box(CreateBoxInput(length=10.0, width=10.0, height=10.0))
+    assert isinstance(box, Success) and box.shape is not None
+
+    for edge_id in box.shape.edge_ids:
+        result = backend.fillet_edges(
+            FilletEdgesInput(shape_id=box.shape_id, edge_ids=[edge_id], radius=0.5)
+        )
+        assert isinstance(result, Success), f"{edge_id} could not be filleted"
+
+
 def test_create_cylinder(backend):
     from math import pi
 


### PR DESCRIPTION
## Problem

An edge belongs to every face that meets along it, and `TopExp_Explorer` yields it once **per face**. Walking the explorer directly reports a box as having 24 edges instead of 12:

```python
box = BRepPrimAPI_MakeBox(10., 5., 3.).Shape()
# TopExp_Explorer over TopAbs_EDGE -> 24
# TopExp.MapShapes_s  over TopAbs_EDGE -> 12   <- correct
```

This is why **`test_create_box` currently fails on `main`** (`assert 24 == 12`). It only surfaces once the OCCT extra is installed — without CadQuery/OCP the whole module is skipped, so the failure sits latent.

The duplication fed the entire selector chain, in three places that all walked the explorer independently:

- `_edge_list` → `ShapeData.edge_ids`
- `_build_topology_map` → the `SubshapeRef`s that `Part._resolve_edge_ids` reads
- `_edge_by_index` → fillet and chamfer target resolution

So `fillet(edges="all")` passed half the edges twice, and the `"top"` selector — `topology.edges[:4]` — covered only two distinct edges. Indices past the real edge count pointed at repeats rather than raising.

## Fix

Enumerate through `TopTools_IndexedMapOfShape` via `TopExp.MapShapes_s`, which keys on shape identity and lists each edge once while preserving traversal order. All three call sites now go through one `_edges_from_shape` helper, so IDs, topology refs, and index lookups can't drift apart.

Faces are deliberately left on the explorer: a face belongs to a single shell, so it's already enumerated once, and changing it would renumber face IDs that `_inherit_modified_face_owners` and the tessellation face groups depend on.

## Verified counts

| shape | before | after |
|---|---|---|
| box | 24 | **12** |
| cylinder | 6 | **3** (two rims + seam) |
| sphere | 6 | **3** |

## Tests

- `test_primitive_edges_are_counted_once_each` — box/cylinder/sphere counts.
- `test_edge_ids_are_unique_and_match_the_topology_map` — `shape.edge_ids` and `get_topology()` agree, and IDs are unique.
- `test_every_enumerated_edge_is_filletable` — every one of a box's 12 edges resolves to a distinct filletable edge.

`227 passed, 1 skipped`, up from `1 failed, 223 passed` on `main`. `test_create_box` now passes unmodified.

## Upgrade note

Edge IDs are renumbered, so any feature tree that persisted an ID with an index at or above the real edge count (e.g. `box-0001:edge:15`) will no longer resolve. Those IDs previously named duplicates of an already-listed edge, so nothing that was addressable becomes unaddressable — but stored fillet selections may need re-picking.

## Context

Found while modelling a bottle through the fluent API — the unreliable `"top"` selector was why I ended up building chamfers into the sketch profile instead of using `fillet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)