### PR TITLE
feat: expose revolve, loft, and sweep on the fluent Part API

### DIFF
--- a/packages/opencad/src/opencad/part.py
+++ b/packages/opencad/src/opencad/part.py
@@ -110,6 +110,81 @@ class Part:
             tree_parameters={"sketch_id": sketch.feature_id, "distance": depth, "both": both},
         )
 
+    def revolve(
+        self,
+        sketch: Sketch,
+        *,
+        axis_origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        axis_direction: tuple[float, float, float] = (0.0, 0.0, 1.0),
+        angle: float = 360.0,
+        name: str = "Revolve",
+    ) -> Self:
+        """Sweep a profile around an axis. The profile must not cross the axis."""
+        sketch_shape_id = sketch.build()
+        if sketch.feature_id is None:
+            raise RuntimeError("Sketch was built without a feature ID.")
+        return self._apply(
+            "revolve",
+            {
+                "shape_id": sketch_shape_id,
+                "axis_origin": axis_origin,
+                "axis_direction": axis_direction,
+                "angle": angle,
+            },
+            feature_name=name,
+            sketch_id=sketch.feature_id,
+            tree_parameters={
+                "shape_id": sketch.feature_id,
+                "axis_origin": axis_origin,
+                "axis_direction": axis_direction,
+                "angle": angle,
+            },
+        )
+
+    def loft(
+        self,
+        sketches: list[Sketch],
+        *,
+        solid: bool = True,
+        ruled: bool = False,
+        name: str = "Loft",
+    ) -> Self:
+        """Blend through two or more ordered profiles."""
+        if len(sketches) < 2:
+            raise ValueError("Loft needs at least two profiles.")
+        shape_ids = [sketch.build() for sketch in sketches]
+        feature_ids = [sketch.feature_id for sketch in sketches]
+        if any(feature_id is None for feature_id in feature_ids):
+            raise RuntimeError("Sketch was built without a feature ID.")
+        return self._apply(
+            "loft",
+            {"profile_ids": shape_ids, "solid": solid, "ruled": ruled},
+            feature_name=name,
+            depends_on=feature_ids,
+            tree_parameters={
+                "profile_ids": feature_ids,
+                "solid": solid,
+                "ruled": ruled,
+            },
+        )
+
+    def sweep(self, profile: Sketch, path: Sketch, *, name: str = "Sweep") -> Self:
+        """Drag a profile along a path wire."""
+        profile_shape_id = profile.build()
+        path_shape_id = path.build()
+        if profile.feature_id is None or path.feature_id is None:
+            raise RuntimeError("Sketch was built without a feature ID.")
+        return self._apply(
+            "sweep",
+            {"profile_id": profile_shape_id, "path_id": path_shape_id},
+            feature_name=name,
+            depends_on=[profile.feature_id, path.feature_id],
+            tree_parameters={
+                "profile_id": profile.feature_id,
+                "path_id": path.feature_id,
+            },
+        )
+
     def union(self, other: Part, *, name: str = "Union") -> Self:
         left_feature, left_shape = self._require_shape()
         right_feature, right_shape = other._require_shape()

--- a/packages/opencad/tests/runtime/test_fluent_api.py
+++ b/packages/opencad/tests/runtime/test_fluent_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+import math
 from pathlib import Path
 
 import pytest
@@ -74,3 +76,87 @@ def test_fluent_sketch_writes_profile_order_metadata() -> None:
     assert isinstance(profile_order, list)
     assert len(profile_order) == len(entities)
     assert any(bool(v.get("subtract")) for v in entities.values() if v.get("type") == "circle")
+
+
+# ── Revolve / loft / sweep ──────────────────────────────────────────
+
+
+def test_fluent_revolve_records_its_sketch() -> None:
+    reset_default_context()
+    profile = Sketch(name="Ring section", plane="XZ").rect(5, 8, origin=(10.0, 0.0))
+    part = Part().revolve(profile, axis_direction=(0.0, 0.0, 1.0), angle=360.0)
+
+    ctx = get_default_context()
+    assert part.feature_id is not None
+    node = ctx.tree.nodes[part.feature_id]
+
+    assert node.operation == "revolve"
+    assert node.sketch_id == profile.feature_id
+    assert node.parameters["shape_id"] == profile.feature_id
+    assert node.parameters["angle"] == 360.0
+
+
+def test_fluent_loft_records_every_profile() -> None:
+    reset_default_context()
+    bottom = Sketch(name="Bottom").circle(5.0)
+    top = Sketch(name="Top", origin=(0.0, 0.0, 10.0)).circle(2.0)
+    part = Part().loft([bottom, top])
+
+    ctx = get_default_context()
+    assert part.feature_id is not None
+    node = ctx.tree.nodes[part.feature_id]
+
+    assert node.operation == "loft"
+    assert node.parameters["profile_ids"] == [bottom.feature_id, top.feature_id]
+    assert node.depends_on == [bottom.feature_id, top.feature_id]
+
+
+def test_fluent_loft_rejects_a_single_profile() -> None:
+    reset_default_context()
+    with pytest.raises(ValueError, match="at least two profiles"):
+        Part().loft([Sketch().circle(5.0)])
+
+
+def test_fluent_sweep_records_profile_and_path() -> None:
+    reset_default_context()
+    profile = Sketch(name="Profile").circle(1.0)
+    path = Sketch(name="Path", plane="XZ").line((0.0, 0.0), (0.0, 20.0))
+    part = Part().sweep(profile, path)
+
+    ctx = get_default_context()
+    assert part.feature_id is not None
+    node = ctx.tree.nodes[part.feature_id]
+
+    assert node.operation == "sweep"
+    assert node.parameters["profile_id"] == profile.feature_id
+    assert node.parameters["path_id"] == path.feature_id
+    assert node.depends_on == [profile.feature_id, path.feature_id]
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("OCP") is None, reason="CadQuery/OCP not installed"
+)
+def test_fluent_revolve_builds_a_real_annulus() -> None:
+    """A rectangle offset from the axis sweeps into a tube, so the result is
+    checkable against pi * (ro^2 - ri^2) * h."""
+    import cadquery as cq
+
+    from opencad.kernel.core.backend_factory import create_backend
+    from opencad.runtime import RuntimeContext, set_default_context
+
+    ctx = RuntimeContext(backend=create_backend("occt", require_native=True))
+    set_default_context(ctx)
+    try:
+        inner, thickness, height = 10.0, 5.0, 8.0
+        profile = Sketch(name="Tube section", plane="XZ").rect(
+            thickness, height, origin=(inner, 0.0)
+        )
+        part = Part().revolve(profile)
+
+        assert part.shape_id is not None
+        native = ctx.registry.kernel.get_native_shape(part.shape_id)
+        outer = inner + thickness
+        expected = math.pi * (outer**2 - inner**2) * height
+        assert cq.Shape(native).Volume() == pytest.approx(expected, rel=0.001)
+    finally:
+        reset_default_context()


### PR DESCRIPTION
## Problem

The kernel implements and registers `revolve`, `sweep`, and `loft` in **both** backends, and `OperationRegistry._register_defaults` wires all three. But `Part` only surfaces `extrude`, so none of them are reachable from the fluent API.

Reaching them means dropping to `context.execute_operation` by hand, or subclassing `Part` to get at the protected `_apply`:

```python
class SolidPart(Part):
    def revolve(self, sketch, *, axis_origin, axis_direction, angle=360.0, name="Revolve"):
        sketch_shape_id = sketch.build()
        return self._apply("revolve", {...}, feature_name=name,
                           sketch_id=sketch.feature_id,
                           tree_parameters={...})   # hand-written, easy to get wrong
```

The `tree_parameters` mapping is the part that bites: get it wrong and the feature still builds but no longer rebuilds, because the tree stores shape IDs where it needs feature IDs.

## Change

Three methods next to `extrude`, following its existing conventions:

```python
Part().revolve(profile, axis_origin=(0,0,0), axis_direction=(0,0,1), angle=360.0)
Part().loft([bottom, top], solid=True, ruled=False)
Part().sweep(profile, path)
```

- `revolve` carries `sketch_id`, like `extrude`, so the profile stays linked for editing.
- `loft` and `sweep` record every input profile in `depends_on`, matching how `union`/`cut` record their operands.
- `loft` raises `ValueError` for fewer than two profiles instead of failing inside OCCT's `ThruSections`.
- All three map feature IDs (not shape IDs) into `tree_parameters`, so features rebuild.

No behaviour changes to anything existing — this is additive.

## Tests

Five tests in `tests/runtime/test_fluent_api.py`. Four assert tree wiring on the default analytic backend (operation, `sketch_id`, `depends_on`, `profile_ids`, and the `ValueError` guard). One is OCCT-guarded and checks real geometry: a rectangle offset from the axis revolves into a tube, verified against `π(ro² - ri²)h` to 0.1%.

`228 passed, 1 failed, 1 skipped`. The failure is `test_create_box`, pre-existing on `main` and unrelated (24 edge IDs for a box instead of 12) — fixed separately in #84.

## Context

Found while modelling a threaded bottle: the neck thread is a loft through 37 circular sections along a helix, and the body is a revolved half-section. Both required the subclass workaround above.

Note that `Sketch` still has no `.arc()` accessor, so arcs remain unreachable from the fluent API. That's in #83 with the arc kernel fix, since the two are only useful together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)