### PR TITLE
docs: keep the occt extra in every documented sync command

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -10,12 +10,15 @@ uv sync --all-packages --all-extras --group test
 pnpm install
 ```
 
+Omitting `--all-extras` leaves the OCCT B-rep backend uninstalled, and the
+kernel then falls back to the analytic backend, which cannot export STEP.
+
 To work on a single Python package with only its own dependencies present:
 
 ```bash
-uv sync --package opencad --group test          # core alone, no web stack
-uv sync --package opencad-agent --group test    # core + agent
-uv sync --package opencad-backend --group test  # everything
+uv sync --package opencad --extra occt --group test          # core alone, no web stack
+uv sync --package opencad-agent --group test                 # core + agent
+uv sync --package opencad-backend --extra occt --group test  # everything
 ```
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -112,12 +112,16 @@ uv sync --all-packages --all-extras --group test
 cp .env.example .env
 ```
 
+Keep `--all-extras`. The OCCT B-rep backend ships behind the `occt` extra, and
+without it the kernel falls back to the analytic backend, which cannot export
+STEP.
+
 To work on one package in isolation, sync only its dependencies:
 
 ```bash
-uv sync --package opencad --group test          # core alone, no web stack
-uv sync --package opencad-agent --group test    # core + agent
-uv sync --package opencad-backend --group test  # everything
+uv sync --package opencad --extra occt --group test          # core alone, no web stack
+uv sync --package opencad-agent --group test                 # core + agent
+uv sync --package opencad-backend --extra occt --group test  # everything
 ```
 
 ### 2. Start backend services
@@ -242,15 +246,19 @@ See `SECURITY.md` for coordinated vulnerability reporting.
 Run the whole workspace:
 
 ```bash
-uv sync --all-packages --group test
+uv sync --all-packages --all-extras --group test
 uv run --no-sync python -m pytest
 ```
+
+Without `--all-extras` the OCCT backend is absent, and the tests that need real
+B-rep geometry skip rather than fail — so the suite still reports green while
+leaving the native kernel untested.
 
 Or test one package with only its own dependencies installed — this is what CI
 does, and it is what keeps the core independent of the backend:
 
 ```bash
-uv sync --package opencad --group test
+uv sync --package opencad --extra occt --group test
 cd packages/opencad && uv run --no-sync --package opencad --project ../.. python -m pytest
 ```
 

--- a/packages/opencad/src/opencad/kernel/core/analytic_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/analytic_backend.py
@@ -468,7 +468,7 @@ class AnalyticBackend:
         return make_failure(
             code=ErrorCode.UNSUPPORTED_STEP,
             message="The analytic backend cannot export STEP geometry.",
-            suggestion="Use the OCCT backend and install it with: uv sync --extra occt",
+            suggestion="Use the OCCT backend and install it with: uv sync --extra occt --group test",
             failed_check="native_geometry_backend",
         )
 

--- a/packages/opencad/src/opencad/kernel/core/backend_factory.py
+++ b/packages/opencad/src/opencad/kernel/core/backend_factory.py
@@ -40,7 +40,7 @@ def create_backend(
         if require_native:
             raise BackendUnavailableError(
                 "The analytic backend cannot export a real STEP or STL file. "
-                "Use --backend occt and install it with: uv sync --extra occt"
+                "Use --backend occt and install it with: uv sync --extra occt --group test"
             )
         return AnalyticBackend(id_strategy=id_strategy)
 
@@ -50,7 +50,7 @@ def create_backend(
         if name == "occt" or require_native:
             raise BackendUnavailableError(
                 "The OCCT backend is required but CadQuery/OCP is not installed. "
-                "Install it with: uv sync --extra occt"
+                "Install it with: uv sync --extra occt --group test"
             ) from exc
     else:
         if HAS_OCCT:
@@ -59,7 +59,7 @@ def create_backend(
     if name == "occt" or require_native:
         raise BackendUnavailableError(
             "The OCCT backend is required but CadQuery/OCP is not installed. "
-            "Install it with: uv sync --extra occt"
+            "Install it with: uv sync --extra occt --group test"
         )
 
     return AnalyticBackend(id_strategy=id_strategy)

--- a/packages/opencad/src/opencad/kernel/core/occt_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/occt_backend.py
@@ -1,7 +1,7 @@
 """OCCT geometry backend powered by CadQuery / OCP.
 
 Implements :class:`KernelBackend` with real B-rep geometry via
-OpenCASCADE Technology. Install with ``uv sync --extra occt``.
+OpenCASCADE Technology. Install with ``uv sync --extra occt --group test``.
 
 """
 
@@ -199,7 +199,7 @@ def _require_occt() -> None:
     if not HAS_OCCT:
         raise RuntimeError(
             "CadQuery / OCP is required for the OCCT backend.  "
-            "Install with: uv sync --extra occt"
+            "Install with: uv sync --extra occt --group test"
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,12 @@
 #   packages/opencad-agent   LLM agent, depends on the core
 #   apps/backend             FastAPI transport, depends on both
 #
-# Sync everything for development:  uv sync --all-packages --group test
+# Sync everything for development:  uv sync --all-packages --all-extras --group test
 # Run the full suite:               uv run --all-packages python -m pytest
+#
+# Keep --all-extras: the OCCT B-rep backend lives behind the opencad "occt"
+# extra, and without it the kernel falls back to the analytic backend, which
+# cannot export STEP. Dropping --group test likewise removes pytest.
 
 [tool.uv.workspace]
 members = [


### PR DESCRIPTION
## Problem

The dev-setup instructions disagree with each other about whether to include extras.

**Correct today:** `CONTRIBUTION.md:9` and the install section of `README.md:111` use `--all-extras`.

**Missing the extra:** the `pyproject.toml` header comment, the README Testing section, and every per-package command:

```
pyproject.toml:8   uv sync --all-packages --group test
README.md:245      uv sync --all-packages --group test
README.md:118-120  uv sync --package opencad --group test          (+ agent, backend)
CONTRIBUTION.md:16-18  same three
```

Follow any of those and the OCCT backend is removed:

```console
$ uv sync --all-packages --group test --dry-run
Would uninstall 28 packages
 - cadquery==2.7.0
 - cadquery-ocp==7.8.1.1.post1
```

The kernel then silently falls back to the analytic backend and STEP export stops working — `BackendUnavailableError: The OCCT backend is required but CadQuery/OCP is not installed`.

The remedy the backends suggest has the mirror-image problem. Six sites tell you to run plain `uv sync --extra occt`, which drops the test group:

```console
$ uv sync --extra occt --dry-run
Would uninstall 3 packages
 - pytest==9.0.3
```

So the documented dev setup costs you the native backend, and the documented fix for that costs you pytest.

## Changes

- `pyproject.toml`, `README.md` Testing section: add `--all-extras`, with a note on why it matters.
- Per-package commands in `README.md` and `CONTRIBUTION.md`: add `--extra occt` for `opencad` and `opencad-backend`. Left `opencad-agent` alone — it defines only an `llm` extra, no `occt`.
- The six `uv sync --extra occt` messages in `occt_backend.py`, `analytic_backend.py`, and `backend_factory.py`: add `--group test`.
- Noted in the Testing section that a run without the extra **skips** the native-geometry tests rather than failing, so the suite still reports green while leaving the OCCT kernel untested.

## Verified

Every command the docs now recommend, dry-run against a fully synced tree — none removes `cadquery`, `cadquery-ocp`, or `pytest`, and none errors:

```
uv sync --all-packages --all-extras --group test        ok
uv sync --extra occt --group test                       ok
uv sync --package opencad --extra occt --group test     ok
uv sync --package opencad-backend --extra occt --group test  ok
```

`223 passed, 1 failed, 1 skipped` — unchanged from `main`. The failure is `test_create_box` (24 edge IDs for a box instead of 12), fixed separately in #84. Notably that failure is itself a symptom of this issue: without the occt extra the whole module is skipped, so the bug sat latent rather than failing CI.

## Context

Hit this setting up to model a part: the repo's own dev-setup line left me without a native backend, and the error message's fix then removed pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
