### PR TITLE
Add OpenClaw, NemoClaw, and OpenCode compatibility; release 0.2.3

### DIFF
--- a/.agents/skills/create-cad-files/SKILL.md
+++ b/.agents/skills/create-cad-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-cad-files
-description: Create dimensioned 3D CAD parts from natural-language requirements and export validated STEP, STP, or STL files with OpenCAD. Use when a user asks Claude or Codex to model a mechanical part, make a printable STL, create an editable STEP file, convert a dimensional description into CAD, or revise a previously generated OpenCAD model.
+description: Create dimensioned 3D CAD parts from natural-language requirements and export validated STEP, STP, or STL files with OpenCAD. Use when a user asks an AI agent to model a mechanical part, make a printable STL, create an editable STEP file, convert a dimensional description into CAD, or revise a previously generated OpenCAD model.
 ---
 
 # Create CAD Files

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,9 +7,9 @@
     "displayName": "OpenCAD"
   },
   "metadata": {
-    "description": "Natural-language CAD generation for Claude and Codex."
+    "description": "Natural-language CAD generation for AI coding agents."
   },
-  "description": "Natural-language CAD generation for Claude and Codex.",
+  "description": "Natural-language CAD generation for AI coding agents.",
   "version": "0.1.0",
   "plugins": [
     {

--- a/.opencode/skills/create-cad-files/SKILL.md
+++ b/.opencode/skills/create-cad-files/SKILL.md
@@ -5,4 +5,4 @@ description: Create dimensioned 3D CAD parts from natural-language requirements 
 
 # Create CAD Files
 
-Read [the packaged skill instructions](../../../skills/create-cad-files/SKILL.md) completely and follow them. Resolve all referenced scripts and references from `skills/create-cad-files/`; this Claude adapter and the installable plugin intentionally share one implementation.
+Read [the packaged skill instructions](../../../skills/create-cad-files/SKILL.md) completely and follow them. Resolve all referenced scripts and references from `skills/create-cad-files/`; this OpenCode adapter and the installable skill intentionally share one implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.2.3 - 2026-08-20
+
+Published: `opencad`, `opencad-agent`, and `opencad-backend` on PyPI.
+
+### Agent compatibility
+
+- Added native OpenCode discovery through `.opencode/skills`.
+- Documented direct OpenClaw workspace discovery and NemoClaw sandbox
+  installation for the packaged `create-cad-files` skill.
+- Made skill discovery metadata portable across Claude Code, Codex, OpenCode,
+  OpenClaw, and NemoClaw while retaining one canonical workflow.
+
+### Modelling and export improvements since 0.2.1
+
+- Added fluent revolve, loft, sweep, and sketch-arc modelling operations.
+- Corrected extrusion along non-XY sketch plane normals and eliminated
+  duplicate topology edge identifiers.
+- Added headless turntable GIF and MP4 export with configurable rendering,
+  plus animated example renders.
+
+### Release engineering
+
+- Advanced all package metadata to 0.2.3 and kept Python dependency pins in
+  exact lockstep. Version 0.2.2 remains the existing GitHub-only release; the
+  Python indexes advance from 0.2.1 directly to 0.2.3.
+
 ## 0.2.1 - 2026-08-01
 
 ### Corrected license metadata

--- a/README.md
+++ b/README.md
@@ -15,12 +15,24 @@ A modular CAD system for parametric, programmable, and AI-assisted design
   <img src="docs/assets/drone-assembly-propellers.gif" width="32%" alt="Drone assembly propellers" />
 </p>
 
-## Install for Claude or Codex
+## Install for Claude, Codex, OpenCode, OpenClaw, or NemoClaw
 
-Install the OpenCAD skill with one command:
+Install the OpenCAD skill for Claude, Codex, OpenCode, or OpenClaw with one
+command:
 
 ```bash
 npx skills add caid-technologies/OpenCAD
+```
+
+OpenClaw also discovers `skills/create-cad-files` directly when this repository
+is its workspace. OpenCode can discover the checked-in adapters under both
+`.opencode/skills` and `.agents/skills`.
+
+For a running NemoClaw sandbox, install the canonical skill from a checkout of
+this repository (replace `my-assistant` with the sandbox name):
+
+```bash
+nemoclaw my-assistant skill install ./skills/create-cad-files
 ```
 
 Then ask the agent normally:
@@ -100,7 +112,7 @@ plate.fillet(edges="all", radius=1.0)
 ```
 
 Cross-package versions move in lockstep and are pinned exactly, so
-`opencad-agent 0.2.0` can only resolve against `opencad 0.2.0`.
+`opencad-agent 0.2.3` can only resolve against `opencad 0.2.3`.
 
 The React components ship separately on npm:
 
@@ -358,13 +370,16 @@ context.export_turntable(
 )
 ```
 
-## Claude and Codex skill
+## Agent skill
 
 The installable `create-cad-files` skill lives under `skills/create-cad-files`.
-Small repository adapters under `.agents/skills` and `.claude/skills` make the
-same workflow available automatically while developing OpenCAD. It turns a
-dimensional request into an OpenCAD Python model, then atomically exports and
-validates STEP, STP, or STL.
+Small repository adapters under `.agents/skills`, `.claude/skills`, and
+`.opencode/skills` make the same workflow available automatically while
+developing OpenCAD. OpenClaw reads the canonical `skills/` directory directly,
+and NemoClaw can upload that directory with `nemoclaw <sandbox> skill install`.
+Every integration uses the same instructions, scripts, and references. The
+skill turns a dimensional request into an OpenCAD Python model, then atomically
+exports and validates STEP, STP, or STL.
 
 ## Examples
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad-backend"
-version = "0.2.1"
+version = "0.2.3"
 description = "OpenCAD HTTP backend — FastAPI transport over the OpenCAD core and agent"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,8 +24,8 @@ classifiers = [
 ]
 # The only place FastAPI, httpx, and uvicorn are allowed.
 dependencies = [
-  "opencad==0.2.1",
-  "opencad-agent[llm]==0.2.1",
+  "opencad==0.2.3",
+  "opencad-agent[llm]==0.2.3",
   "fastapi>=0.100",
   "httpx>=0.27",
   "python-dotenv>=1.0",

--- a/apps/opencad_viewport/package.json
+++ b/apps/opencad_viewport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencad-viewport-app",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Reference application that hosts the OpenCAD viewport components",
   "private": true,
   "type": "module",

--- a/packages/opencad-agent/pyproject.toml
+++ b/packages/opencad-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad-agent"
-version = "0.2.1"
+version = "0.2.3"
 description = "OpenCAD AI agent — natural-language modelling on top of the OpenCAD core"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ classifiers = [
 ]
 # Depends on the core distribution and nothing web-facing.
 dependencies = [
-  "opencad==0.2.1",
+  "opencad==0.2.3",
   "pydantic>=2",
 ]
 

--- a/packages/opencad-viewport/package.json
+++ b/packages/opencad-viewport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencad-viewport",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "React + Three.js viewport components for OpenCAD — 3D viewport, feature tree, sketch editor, and chat panel",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/opencad/pyproject.toml
+++ b/packages/opencad/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencad"
-version = "0.2.1"
+version = "0.2.3"
 description = "OpenCAD core — geometry kernel, constraint solver, feature tree, and fluent modelling API"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/opencad/src/opencad/version.py
+++ b/packages/opencad/src/opencad/version.py
@@ -1,3 +1,3 @@
 """OpenCAD package version."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"

--- a/skills/create-cad-files/SKILL.md
+++ b/skills/create-cad-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-cad-files
-description: Create dimensioned 3D CAD parts from natural-language requirements and export validated STEP, STP, or STL files with OpenCAD. Use when a user asks Claude or Codex to model a mechanical part, make a printable STL, create an editable STEP file, convert a dimensional description into CAD, or revise a previously generated OpenCAD model.
+description: Create dimensioned 3D CAD parts from natural-language requirements and export validated STEP, STP, or STL files with OpenCAD. Use when a user asks an AI agent to model a mechanical part, make a printable STL, create an editable STEP file, convert a dimensional description into CAD, or revise a previously generated OpenCAD model.
 ---
 
 # Create CAD Files

--- a/uv.lock
+++ b/uv.lock
@@ -1979,7 +1979,7 @@ wheels = [
 
 [[package]]
 name = "opencad"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "packages/opencad" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2054,7 +2054,7 @@ test = [
 
 [[package]]
 name = "opencad-agent"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "packages/opencad-agent" }
 dependencies = [
     { name = "opencad" },
@@ -2084,7 +2084,7 @@ test = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "opencad-backend"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "apps/backend" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- add native OpenCode skill discovery and portable agent metadata
- document OpenClaw workspace discovery and NemoClaw sandbox installation
- prepare the lockstep 0.2.3 release across Python and viewport packages
- add release notes covering modelling and turntable improvements since PyPI 0.2.1

## Validation

- clean Python 3.11 workspace suite: 346 passed, 49 skipped
- viewport suite: 22 passed
- viewport library and reference app production builds
- npm package dry run
- all skill entry points pass quick validation
- all Python distributions pass twine checks and wheel metadata pin checks