### PR TITLE
fix: organize generated CAD projects around assembly.py

### DIFF
--- a/packages/opencad/src/opencad/cli.py
+++ b/packages/opencad/src/opencad/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import runpy
+import sys
 from pathlib import Path
 
 from opencad.runtime import RuntimeContext, get_default_context, set_default_context
@@ -155,7 +156,15 @@ def _cmd_run(args: argparse.Namespace) -> int:
     if not script_path.exists():
         raise FileNotFoundError(f"Script not found: {script_path}")
 
-    runpy.run_path(str(script_path), run_name="__main__")
+    script_directory = str(script_path.resolve().parent)
+    added_script_directory = script_directory not in sys.path
+    if added_script_directory:
+        sys.path.insert(0, script_directory)
+    try:
+        runpy.run_path(str(script_path), run_name="__main__")
+    finally:
+        if added_script_directory:
+            sys.path.remove(script_directory)
 
     current = get_default_context()
     if args.export:

--- a/packages/opencad/tests/runtime/test_cad_file_builder.py
+++ b/packages/opencad/tests/runtime/test_cad_file_builder.py
@@ -24,18 +24,26 @@ def test_build_helper_supports_sibling_modules(tmp_path: Path) -> None:
     if importlib.util.find_spec("cadquery") is None or importlib.util.find_spec("OCP") is None:
         pytest.skip("OCCT is not installed")
 
-    components_path = tmp_path / "components.py"
+    package_path = tmp_path / "components" / "motor" / "mount"
+    package_path.mkdir(parents=True)
+    for init_path in [
+        tmp_path / "components" / "__init__.py",
+        tmp_path / "components" / "motor" / "__init__.py",
+        package_path / "__init__.py",
+    ]:
+        init_path.write_text("", encoding="utf-8")
+    components_path = package_path / "screw_pattern.py"
     assembly_path = tmp_path / "assembly.py"
     output_path = tmp_path / "assembly.step"
     components_path.write_text(
         "from opencad import Part\n\n"
-        "def make_base():\n"
-        "    return Part(name='Base').box(10, 10, 2)\n",
+        "def make_screw_pattern():\n"
+        "    return Part(name='Screw Pattern').box(10, 10, 2)\n",
         encoding="utf-8",
     )
     assembly_path.write_text(
-        "from components import make_base\n\n"
-        "result = make_base()\n",
+        "from components.motor.mount.screw_pattern import make_screw_pattern\n\n"
+        "result = make_screw_pattern()\n",
         encoding="utf-8",
     )
 

--- a/packages/opencad/tests/runtime/test_cad_file_builder.py
+++ b/packages/opencad/tests/runtime/test_cad_file_builder.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_builder():
+    scripts_dir = Path(__file__).resolve().parents[4] / "skills" / "create-cad-files" / "scripts"
+    spec = importlib.util.spec_from_file_location("create_cad_file_builder", scripts_dir / "build_cad_file.py")
+    assert spec is not None and spec.loader is not None
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(scripts_dir))
+
+
+def test_build_helper_supports_sibling_modules(tmp_path: Path) -> None:
+    if importlib.util.find_spec("cadquery") is None or importlib.util.find_spec("OCP") is None:
+        pytest.skip("OCCT is not installed")
+
+    components_path = tmp_path / "components.py"
+    assembly_path = tmp_path / "assembly.py"
+    output_path = tmp_path / "assembly.step"
+    components_path.write_text(
+        "from opencad import Part\n\n"
+        "def make_base():\n"
+        "    return Part(name='Base').box(10, 10, 2)\n",
+        encoding="utf-8",
+    )
+    assembly_path.write_text(
+        "from components import make_base\n\n"
+        "result = make_base()\n",
+        encoding="utf-8",
+    )
+
+    builder = _load_builder()
+    summary = builder.build_cad_file(assembly_path, output_path)
+
+    assert summary["model_path"] == str(assembly_path.resolve())
+    assert output_path.exists()

--- a/packages/opencad/tests/runtime/test_cli.py
+++ b/packages/opencad/tests/runtime/test_cli.py
@@ -116,9 +116,22 @@ def test_cli_auto_step_export_requires_occt_install(tmp_path: Path) -> None:
 
 
 def test_cli_tree_only_run_supports_analytic_backend(tmp_path: Path) -> None:
+    components_dir = tmp_path / "components"
+    components_dir.mkdir()
+    (components_dir / "__init__.py").write_text("", encoding="utf-8")
+    (components_dir / "base.py").write_text(
+        "from opencad import Part\n\n"
+        "def make_base():\n"
+        "    return Part(name='Base').box(1, 1, 1)\n",
+        encoding="utf-8",
+    )
     script_path = tmp_path / "model.py"
     tree_path = tmp_path / "tree.json"
-    script_path.write_text("from opencad import Part\nPart().box(1, 1, 1)\n", encoding="utf-8")
+    script_path.write_text(
+        "from components.base import make_base\n"
+        "make_base()\n",
+        encoding="utf-8",
+    )
 
     code = main([
         "run",

--- a/skills/create-cad-files/SKILL.md
+++ b/skills/create-cad-files/SKILL.md
@@ -11,17 +11,17 @@ Create the model as readable OpenCAD Python, export it with the native OCCT back
 
 1. Extract dimensions, units, geometry, holes, clearances, and output format. Use millimeters unless specified otherwise. Ask only when a missing dimension materially changes the part; otherwise state the assumption.
 2. Prefer STEP for editable/manufacturing geometry and STL for a triangulated 3D-printing deliverable. Create both when requested.
-3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. Save the model source beside its artifacts in the user's workspace.
-4. Keep the model parametric: assign important dimensions to named constants, create one final `Part`, and leave that final part as the last generated shape. Do not call `Part.export()` in the model; the build helper owns export and validation.
+3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. Save the model source beside its artifacts in the user's workspace. For multi-file models, use `assembly.py` as the master entry point by default; keep supporting parts and helpers in nearby Python modules and import them from `assembly.py`. Honor an explicitly requested source filename instead.
+4. Keep the model parametric: assign important dimensions to named constants, create one final `Part`, and leave that final part as the last generated shape in `assembly.py` (or the explicitly requested master file). Do not call `Part.export()` in the model; the build helper owns export and validation.
 5. Ensure `opencad[occt]` is installed. If importing OpenCAD fails, explain the dependency and ask before installing it into the active Python environment.
 6. Resolve this skill's directory, stay in the user's workspace, and run the helper by its absolute path:
 
    ```bash
-   python /path/to/create-cad-files/scripts/build_cad_file.py MODEL.py OUTPUT.step --tree-output OUTPUT.tree.json
+   python /path/to/create-cad-files/scripts/build_cad_file.py assembly.py assembly.step --tree-output assembly.tree.json
    ```
 
    Use an `.stl` output name for STL. The helper refuses to replace files unless `--force` is explicitly supplied.
-7. If exporting both formats, run the same source twice. Validate an existing artifact independently with the absolute path to `scripts/validate_cad_file.py`.
+7. If exporting both formats, run the same `assembly.py` source twice. Validate an existing artifact independently with the absolute path to `scripts/validate_cad_file.py`.
 8. Inspect failures and revise the source rather than bypassing validation. Return clickable paths for the source, CAD artifacts, and feature tree, plus units and assumptions.
 
 ## Quality rules
@@ -32,6 +32,7 @@ Create the model as readable OpenCAD Python, export it with the native OCCT back
 - Keep holes and clearances explicit. Do not invent manufacturing tolerances; flag them when fit matters.
 - Do not claim that basic file validation proves printability, load capacity, code compliance, or manufacturability.
 - Retain the Python source and tree JSON so revisions remain reproducible.
+- Keep `assembly.py`, its supporting modules, and generated artifacts together so the model can be rebuilt from the master entry point.
 
 ## Failure handling
 

--- a/skills/create-cad-files/SKILL.md
+++ b/skills/create-cad-files/SKILL.md
@@ -11,17 +11,17 @@ Create the model as readable OpenCAD Python, export it with the native OCCT back
 
 1. Extract dimensions, units, geometry, holes, clearances, and output format. Use millimeters unless specified otherwise. Ask only when a missing dimension materially changes the part; otherwise state the assumption.
 2. Prefer STEP for editable/manufacturing geometry and STL for a triangulated 3D-printing deliverable. Create both when requested.
-3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. Save the model source beside its artifacts in the user's workspace. For multi-file models, use `assembly.py` as the master entry point by default; keep supporting parts and helpers in nearby Python modules and import them from `assembly.py`. Honor an explicitly requested source filename instead.
-4. Keep the model parametric: assign important dimensions to named constants, create one final `Part`, and leave that final part as the last generated shape in `assembly.py` (or the explicitly requested master file). Do not call `Part.export()` in the model; the build helper owns export and validation.
+3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. Give every project its own directory named from the request unless the user specifies a location. Create `README.md` for project context, `assembly.py` as the master composition entry point, `parameters.py` when dimensions are shared, a `components/` Python package for component modules, and an `outputs/` directory for generated artifacts. Honor explicitly requested filenames or locations instead.
+4. Keep the model parametric: assign important dimensions to named constants, have component modules expose named builders or parts, and create one final `Part` in `assembly.py`. Leave that final part as the last generated shape in `assembly.py` (or the explicitly requested master file). Do not call `Part.export()` in the model; the build helper owns export and validation.
 5. Ensure `opencad[occt]` is installed. If importing OpenCAD fails, explain the dependency and ask before installing it into the active Python environment.
 6. Resolve this skill's directory, stay in the user's workspace, and run the helper by its absolute path:
 
    ```bash
-   python /path/to/create-cad-files/scripts/build_cad_file.py assembly.py assembly.step --tree-output assembly.tree.json
+   python /path/to/create-cad-files/scripts/build_cad_file.py PROJECT/assembly.py PROJECT/outputs/assembly.step --tree-output PROJECT/outputs/assembly.tree.json
    ```
 
    Use an `.stl` output name for STL. The helper refuses to replace files unless `--force` is explicitly supplied.
-7. If exporting both formats, run the same `assembly.py` source twice. Validate an existing artifact independently with the absolute path to `scripts/validate_cad_file.py`.
+7. If exporting both formats, run the same project `assembly.py` source twice. Validate an existing artifact independently with the absolute path to `scripts/validate_cad_file.py`.
 8. Inspect failures and revise the source rather than bypassing validation. Return clickable paths for the source, CAD artifacts, and feature tree, plus units and assumptions.
 
 ## Quality rules
@@ -31,8 +31,10 @@ Create the model as readable OpenCAD Python, export it with the native OCCT back
 - Apply fillets and chamfers after the main solid and boolean operations.
 - Keep holes and clearances explicit. Do not invent manufacturing tolerances; flag them when fit matters.
 - Do not claim that basic file validation proves printability, load capacity, code compliance, or manufacturability.
-- Retain the Python source and tree JSON so revisions remain reproducible.
-- Keep `assembly.py`, its supporting modules, and generated artifacts together so the model can be rebuilt from the master entry point.
+- Retain the project source, `README.md`, and tree JSON so revisions remain reproducible.
+- Keep the project self-contained so `assembly.py`, nested component packages, and generated artifacts can be managed together.
+- Use `__init__.py` files for component packages and subpackages. Import nested components from the project root, for example `from components.motor.mount.screw_pattern import make_screw_pattern`.
+- Document the project purpose, units, assumptions, key dimensions, component/package tree, build command, artifacts, and known limitations in `README.md`.
 
 ## Failure handling
 

--- a/skills/create-cad-files/agents/openai.yaml
+++ b/skills/create-cad-files/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create CAD Files"
   short_description: "Create validated STEP and STL models"
-  default_prompt: "Use $create-cad-files to create a dimensioned CAD model. Use assembly.py as the default master file for multi-file models, keep supporting parts in importable modules beside it, and export validated STEP or STL artifacts."
+  default_prompt: "Use $create-cad-files to create a dimensioned CAD project in its own directory. Create README.md for context, assembly.py as the master composition entry point, nested components/ Python packages for parts and subcomponents, and validated STEP or STL artifacts under outputs/."

--- a/skills/create-cad-files/agents/openai.yaml
+++ b/skills/create-cad-files/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create CAD Files"
   short_description: "Create validated STEP and STL models"
-  default_prompt: "Use $create-cad-files to create a dimensioned CAD model and export it as STEP or STL."
+  default_prompt: "Use $create-cad-files to create a dimensioned CAD model. Use assembly.py as the default master file for multi-file models, keep supporting parts in importable modules beside it, and export validated STEP or STL artifacts."

--- a/skills/create-cad-files/scripts/build_cad_file.py
+++ b/skills/create-cad-files/scripts/build_cad_file.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import runpy
+import sys
 import tempfile
 from pathlib import Path
 
@@ -39,7 +40,15 @@ def _run_model(model_path: Path, output_path: Path, tree_path: Path | None) -> i
 
     context = RuntimeContext(backend=create_backend("occt", require_native=True))
     set_default_context(context)
-    runpy.run_path(str(model_path), run_name="__main__")
+    model_directory = str(model_path.parent)
+    added_model_directory = model_directory not in sys.path
+    if added_model_directory:
+        sys.path.insert(0, model_directory)
+    try:
+        runpy.run_path(str(model_path), run_name="__main__")
+    finally:
+        if added_model_directory:
+            sys.path.remove(model_directory)
     if not context.last_shape_id:
         raise RuntimeError("The model produced no shape to export.")
 


### PR DESCRIPTION
## Summary

- Create each generated CAD request in its own self-contained project directory.
- Use ssembly.py as the master composition entry point.
- Organize parts and subcomponents as nested components/ Python packages.
- Add README.md, optional shared parameters.py, and outputs/ artifact storage.
- Make both the build helper and public CLI resolve project-local imports automatically.
- Add regression coverage for nested component imports.

## Validation

- Python compilation passed.
- git diff --check passed.
- Sandbox generation produced and validated a STEP assembly with the expected project layout.
- Full pytest suite was not run because uv and pytest are unavailable in the environment.

Closes #95