### PR TITLE
feat: use shared workspace for CAD projects

### DIFF
--- a/packages/opencad/tests/runtime/test_skill_workspace.py
+++ b/packages/opencad/tests/runtime/test_skill_workspace.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from uuid import UUID
+
+
+def _load_project_allocator():
+    scripts_dir = Path(__file__).resolve().parents[4] / "skills" / "create-cad-files" / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        "create_cad_project",
+        scripts_dir / "create_project.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_project_allocator_uses_a_generated_uuid_under_the_workspace(tmp_path: Path) -> None:
+    allocator = _load_project_allocator()
+    workspace = tmp_path / "forma-workspace"
+
+    project_path = allocator.create_project_directory(workspace)
+
+    assert project_path.parent == workspace
+    UUID(project_path.name)
+    assert project_path.is_dir()
+
+
+def test_project_allocator_creates_unique_directories(tmp_path: Path) -> None:
+    allocator = _load_project_allocator()
+    workspace = tmp_path / "forma-workspace"
+
+    project_paths = {
+        allocator.create_project_directory(workspace)
+        for _ in range(2)
+    }
+
+    assert len(project_paths) == 2

--- a/skills/create-cad-files/SKILL.md
+++ b/skills/create-cad-files/SKILL.md
@@ -11,13 +11,14 @@ Create the model as readable OpenCAD Python, export it with the native OCCT back
 
 1. Extract dimensions, units, geometry, holes, clearances, and output format. Use millimeters unless specified otherwise. Ask only when a missing dimension materially changes the part; otherwise state the assumption.
 2. Prefer STEP for editable/manufacturing geometry and STL for a triangulated 3D-printing deliverable. Create both when requested.
-3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. Give every project its own directory named from the request unless the user specifies a location. Create `README.md` for project context, `assembly.py` as the master composition entry point, `parameters.py` when dimensions are shared, a `components/` Python package for component modules, and an `outputs/` directory for generated artifacts. Honor explicitly requested filenames or locations instead.
+3. Read [references/opencad-api.md](references/opencad-api.md) before writing a model. At the start of every run, create a fresh project directory with `scripts/create_project.py` and use the returned path as `PROJECT_DIR`. The helper creates a UUID-named directory under `~/forma-workspace/`; never derive the project ID from the request. Keep every source file, README, component, and generated artifact inside `PROJECT_DIR`. Create `README.md` for project context, `assembly.py` as the master composition entry point, `parameters.py` when dimensions are shared, a `components/` Python package for component modules, and an `outputs/` directory for generated artifacts. Honor explicitly requested filenames inside `PROJECT_DIR`, but do not replace the shared root or generated project ID.
 4. Keep the model parametric: assign important dimensions to named constants, have component modules expose named builders or parts, and create one final `Part` in `assembly.py`. Leave that final part as the last generated shape in `assembly.py` (or the explicitly requested master file). Do not call `Part.export()` in the model; the build helper owns export and validation.
 5. Ensure `opencad[occt]` is installed. If importing OpenCAD fails, explain the dependency and ask before installing it into the active Python environment.
-6. Resolve this skill's directory, stay in the user's workspace, and run the helper by its absolute path:
+6. Resolve this skill's directory, create the project directory by its absolute path, stay inside the returned project directory, and run the build helper by its absolute path:
 
    ```bash
-   python /path/to/create-cad-files/scripts/build_cad_file.py PROJECT/assembly.py PROJECT/outputs/assembly.step --tree-output PROJECT/outputs/assembly.tree.json
+   PROJECT_DIR=$(python /path/to/create-cad-files/scripts/create_project.py)
+   python /path/to/create-cad-files/scripts/build_cad_file.py "$PROJECT_DIR/assembly.py" "$PROJECT_DIR/outputs/assembly.step" --tree-output "$PROJECT_DIR/outputs/assembly.tree.json"
    ```
 
    Use an `.stl` output name for STL. The helper refuses to replace files unless `--force` is explicitly supplied.

--- a/skills/create-cad-files/agents/openai.yaml
+++ b/skills/create-cad-files/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create CAD Files"
   short_description: "Create validated STEP and STL models"
-  default_prompt: "Use $create-cad-files to create a dimensioned CAD project in its own directory. Create README.md for context, assembly.py as the master composition entry point, nested components/ Python packages for parts and subcomponents, and validated STEP or STL artifacts under outputs/."
+  default_prompt: "Use $create-cad-files to create a dimensioned CAD project under ~/forma-workspace/<generated-uuid>/. Create the project directory with the bundled allocator, then put README.md, assembly.py, nested components/ Python packages, and validated STEP or STL artifacts under that directory's outputs/."

--- a/skills/create-cad-files/scripts/create_project.py
+++ b/skills/create-cad-files/scripts/create_project.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Create a unique project directory in the shared Forma workspace."""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from pathlib import Path
+
+
+WORKSPACE_NAME = "forma-workspace"
+
+
+def create_project_directory(workspace: str | Path | None = None) -> Path:
+    """Create and return a UUID-named project directory."""
+    workspace_path = (
+        Path(workspace).expanduser()
+        if workspace is not None
+        else Path.home() / WORKSPACE_NAME
+    )
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    while True:
+        project_path = workspace_path / str(uuid.uuid4())
+        try:
+            project_path.mkdir()
+        except FileExistsError:
+            continue
+        return project_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create a Forma workspace project directory")
+    parser.add_argument(
+        "--workspace",
+        help="Workspace root override for tests or isolated environments",
+    )
+    args = parser.parse_args(argv)
+    print(create_project_directory(args.workspace))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a UUID-based project directory allocator under `~/forma-workspace/<uuid>/`
- require the `create-cad-files` workflow to keep source and CAD artifacts inside that directory
- update the OpenAI skill prompt and add allocator coverage

Fixes #99

## Tests
- OpenCAD allocator assertions passed
- `python -m compileall` passed for the helper and tests
- sandbox OpenCAD STEP export and independent validation passed
- Full pytest suite was not run because `pytest` and `uv` are unavailable in the environment
