### PR TITLE
fix: center boxes across geometry backends

### DIFF
--- a/packages/opencad-agent/src/opencad_agent/prompting.py
+++ b/packages/opencad-agent/src/opencad_agent/prompting.py
@@ -59,6 +59,7 @@ Part methods (all return self for chaining):
   .sphere(radius, *, name=str)
   .cone(radius1, radius2, height, *, name=str)
   .torus(major_radius, minor_radius, *, name=str)
+  .translate((dx,dy,dz), *, name=str)
   .extrude(sketch, *, depth, both=False, name=str)   # sketch is a Sketch instance, NO subtract arg
   .union(other_part, *, name=str)
   .cut(other_part, *, name=str)
@@ -130,7 +131,7 @@ def build_code_generation_prompt(tree_state: FeatureTree) -> str:
         "- Prefer `Sketch(name=...)`; if origin is supplied it must be a 3-number tuple, while rect origin and circle center use 2-number tuples.\n"
         "- Create each independent solid from its own Part instance; do not call an operation on a Part that has no shape.\n"
         "- Every union, cut, or intersection requires operands whose bounding boxes overlap. Never boolean disconnected solids.\n"
-        "- Native primitives begin at the world origin and there is no translation method; choose dimensions that overlap there.\n"
+        "- Boxes are centered at the world origin; use .translate((dx,dy,dz), name=...) to position a primitive or feature away from its default origin.\n"
         "- Use the native box, cylinder, sphere, cone, or torus Part method whenever that primitive is requested; do not approximate it with a sketch and extrusion.\n"
         "- A torus must use `Part(name=...).torus(major_radius=..., minor_radius=..., name=...)`.\n"
         "- For radial repetition, sketch one feature away from the axis, extrude it, then use circular_pattern and union it with the core.\n"

--- a/packages/opencad-agent/src/opencad_agent/service.py
+++ b/packages/opencad-agent/src/opencad_agent/service.py
@@ -55,7 +55,7 @@ class OpenCadAgentService:
                     f"Invalid code:\n{generated_code}\n\n"
                     "Fix the exact validation error before returning code. "
                     "Every boolean union, cut, or intersection must use solids whose bounding boxes overlap. "
-                    "Native primitives start at the world origin and OpenCAD has no translation method, so use overlapping dimensions at the origin. "
+                    "Boxes are centered at the world origin; use .translate((dx,dy,dz), name=...) to position a primitive or feature away from its default origin. "
                     "For a screw, use an overlapping narrow cylinder for the shank and a wider short cylinder for the head. "
                     "For every Sketch variable, keep exactly one closed-profile call: one rect or one circle. "
                     "Delete all extra closed-profile calls instead of replacing them. "

--- a/packages/opencad/src/opencad/kernel/core/geometry.py
+++ b/packages/opencad/src/opencad/kernel/core/geometry.py
@@ -7,12 +7,12 @@ from .models import BoundingBox
 
 def box_bbox(length: float, width: float, height: float) -> BoundingBox:
     return BoundingBox(
-        min_x=0.0,
-        min_y=0.0,
-        min_z=0.0,
-        max_x=length,
-        max_y=width,
-        max_z=height,
+        min_x=-length / 2.0,
+        min_y=-width / 2.0,
+        min_z=-height / 2.0,
+        max_x=length / 2.0,
+        max_y=width / 2.0,
+        max_z=height / 2.0,
     )
 
 

--- a/packages/opencad/src/opencad/kernel/core/occt_backend.py
+++ b/packages/opencad/src/opencad/kernel/core/occt_backend.py
@@ -796,7 +796,7 @@ class OcctBackend:
         if payload.length <= self.tolerance or payload.width <= self.tolerance or payload.height <= self.tolerance:
             return self._invalid_input("Box dimensions must be greater than tolerance.")
 
-        wp = cq.Workplane("XY").box(payload.length, payload.width, payload.height, centered=False)
+        wp = cq.Workplane("XY").box(payload.length, payload.width, payload.height, centered=True)
         native = wp.val().wrapped
         shape = self._register_shape("box", native, payload.model_dump())
         return self._success(shape, "create_box")

--- a/packages/opencad/src/opencad/part.py
+++ b/packages/opencad/src/opencad/part.py
@@ -59,6 +59,7 @@ class Part:
         return self
 
     def box(self, length: float, width: float, height: float, *, name: str = "Box") -> Self:
+        """Create a box centered at the modeling origin."""
         return self._apply(
             "create_box",
             {"length": length, "width": width, "height": height},

--- a/packages/opencad/tests/kernel/test_occt_backend.py
+++ b/packages/opencad/tests/kernel/test_occt_backend.py
@@ -35,7 +35,12 @@ def test_create_box(backend):
     assert isinstance(result, Success)
     assert result.shape is not None
     assert result.shape.volume == pytest.approx(150.0, rel=0.01)
-    assert result.shape.bbox.min_x < result.shape.bbox.max_x
+    assert result.shape.bbox.min_x == pytest.approx(-5.0, abs=0.01)
+    assert result.shape.bbox.min_y == pytest.approx(-2.5, abs=0.01)
+    assert result.shape.bbox.min_z == pytest.approx(-1.5, abs=0.01)
+    assert result.shape.bbox.max_x == pytest.approx(5.0, abs=0.01)
+    assert result.shape.bbox.max_y == pytest.approx(2.5, abs=0.01)
+    assert result.shape.bbox.max_z == pytest.approx(1.5, abs=0.01)
     assert len(result.shape.edge_ids) == 12  # A box has 12 edges
 
 

--- a/packages/opencad/tests/kernel/test_operations.py
+++ b/packages/opencad/tests/kernel/test_operations.py
@@ -61,6 +61,12 @@ def test_create_box_success(kernel: OpenCadKernel) -> None:
     assert result.ok
     assert result.shape is not None
     assert result.shape.volume == pytest.approx(24.0)
+    assert result.shape.bbox.min_x == pytest.approx(-1.0)
+    assert result.shape.bbox.min_y == pytest.approx(-1.5)
+    assert result.shape.bbox.min_z == pytest.approx(-2.0)
+    assert result.shape.bbox.max_x == pytest.approx(1.0)
+    assert result.shape.bbox.max_y == pytest.approx(1.5)
+    assert result.shape.bbox.max_z == pytest.approx(2.0)
 
 
 def test_create_cylinder_success(kernel: OpenCadKernel) -> None:
@@ -87,12 +93,12 @@ def test_translate_moves_bbox_without_changing_volume(kernel: OpenCadKernel) -> 
     assert result.shape is not None
     assert result.shape.kind == "translate"
     assert result.shape.volume == pytest.approx(box.shape.volume)
-    assert result.shape.bbox.min_x == pytest.approx(10.0)
-    assert result.shape.bbox.min_y == pytest.approx(-2.0)
-    assert result.shape.bbox.min_z == pytest.approx(5.0)
-    assert result.shape.bbox.max_x == pytest.approx(12.0)
-    assert result.shape.bbox.max_y == pytest.approx(1.0)
-    assert result.shape.bbox.max_z == pytest.approx(9.0)
+    assert result.shape.bbox.min_x == pytest.approx(9.0)
+    assert result.shape.bbox.min_y == pytest.approx(-3.5)
+    assert result.shape.bbox.min_z == pytest.approx(3.0)
+    assert result.shape.bbox.max_x == pytest.approx(11.0)
+    assert result.shape.bbox.max_y == pytest.approx(-0.5)
+    assert result.shape.bbox.max_z == pytest.approx(7.0)
 
 
 def test_create_box_invalid_input(kernel: OpenCadKernel) -> None:

--- a/packages/opencad/tests/runtime/test_fluent_api.py
+++ b/packages/opencad/tests/runtime/test_fluent_api.py
@@ -44,6 +44,22 @@ def test_fluent_boolean_chain_records_dependencies() -> None:
     assert len(node.depends_on) == 2
 
 
+def test_fluent_box_is_centered_at_modeling_origin() -> None:
+    reset_default_context()
+    part = Part().box(10, 5, 3)
+
+    ctx = get_default_context()
+    assert part.shape_id is not None
+    box = ctx.kernel.store.get(part.shape_id)
+    assert box is not None
+    assert box.bbox.min_x == pytest.approx(-5.0)
+    assert box.bbox.min_y == pytest.approx(-2.5)
+    assert box.bbox.min_z == pytest.approx(-1.5)
+    assert box.bbox.max_x == pytest.approx(5.0)
+    assert box.bbox.max_y == pytest.approx(2.5)
+    assert box.bbox.max_z == pytest.approx(1.5)
+
+
 def test_fluent_translate_positions_shape_and_records_dependency() -> None:
     reset_default_context()
     part = Part().box(2, 3, 4).translate((10.0, -2.0, 5.0))
@@ -53,12 +69,12 @@ def test_fluent_translate_positions_shape_and_records_dependency() -> None:
     assert part.shape_id is not None
     translated = ctx.kernel.store.get(part.shape_id)
     assert translated is not None
-    assert translated.bbox.min_x == pytest.approx(10.0)
-    assert translated.bbox.min_y == pytest.approx(-2.0)
-    assert translated.bbox.min_z == pytest.approx(5.0)
-    assert translated.bbox.max_x == pytest.approx(12.0)
-    assert translated.bbox.max_y == pytest.approx(1.0)
-    assert translated.bbox.max_z == pytest.approx(9.0)
+    assert translated.bbox.min_x == pytest.approx(9.0)
+    assert translated.bbox.min_y == pytest.approx(-3.5)
+    assert translated.bbox.min_z == pytest.approx(3.0)
+    assert translated.bbox.max_x == pytest.approx(11.0)
+    assert translated.bbox.max_y == pytest.approx(-0.5)
+    assert translated.bbox.max_z == pytest.approx(7.0)
     node = ctx.tree.nodes[part.feature_id]
     assert node.operation == "translate"
     assert node.depends_on == ["feat-0001"]
@@ -69,9 +85,9 @@ def test_fluent_translate_positions_shape_and_records_dependency() -> None:
     assert rebuilt_node.shape_id is not None
     rebuilt = ctx.kernel.store.get(rebuilt_node.shape_id)
     assert rebuilt is not None
-    assert rebuilt.bbox.min_x == pytest.approx(10.0)
-    assert rebuilt.bbox.min_y == pytest.approx(-2.0)
-    assert rebuilt.bbox.min_z == pytest.approx(5.0)
+    assert rebuilt.bbox.min_x == pytest.approx(9.0)
+    assert rebuilt.bbox.min_y == pytest.approx(-3.5)
+    assert rebuilt.bbox.min_z == pytest.approx(3.0)
 
 
 def test_fluent_part_exports_stl_by_extension(tmp_path: Path) -> None:
@@ -104,12 +120,12 @@ def test_fluent_translate_moves_a_real_occt_shape() -> None:
         assert part.shape_id is not None
         translated = ctx.kernel.store.get(part.shape_id)
         assert translated is not None
-        assert translated.bbox.min_x == pytest.approx(10.0)
-        assert translated.bbox.min_y == pytest.approx(-2.0)
-        assert translated.bbox.min_z == pytest.approx(5.0)
-        assert translated.bbox.max_x == pytest.approx(12.0)
-        assert translated.bbox.max_y == pytest.approx(1.0)
-        assert translated.bbox.max_z == pytest.approx(9.0)
+        assert translated.bbox.min_x == pytest.approx(9.0)
+        assert translated.bbox.min_y == pytest.approx(-3.5)
+        assert translated.bbox.min_z == pytest.approx(3.0)
+        assert translated.bbox.max_x == pytest.approx(11.0)
+        assert translated.bbox.max_y == pytest.approx(-0.5)
+        assert translated.bbox.max_z == pytest.approx(7.0)
     finally:
         reset_default_context()
 

--- a/skills/create-cad-files/references/opencad-api.md
+++ b/skills/create-cad-files/references/opencad-api.md
@@ -51,7 +51,7 @@ Build arbitrary planar profiles from consecutive lines and close the final point
 - `.linear_pattern(direction=(...), count=n, spacing=value)`
 - `.circular_pattern(axis_origin=(...), axis_direction=(...), count=n, angle=360)`
 
-Primitive solids start at the modeling origin. Use `.translate((dx, dy, dz))` to position a completed 3-D primitive or other active shape. The operation creates a new positioned feature while preserving the fluent `Part` handle. For booleans, create the target, create the tool, position either shape as needed, then make the target's boolean operation the final call:
+Boxes are centered at the modeling origin in both backends. For example, `Part().box(10, 5, 3)` spans approximately `(-5, -2.5, -1.5)` to `(5, 2.5, 1.5)`. Use `.translate((dx, dy, dz))` to position a completed 3-D primitive or other active shape. The operation creates a new positioned feature while preserving the fluent `Part` handle. For booleans, create the target, create the tool, position either shape as needed, then make the target's boolean operation the final call:
 
 ```python
 outer = Part(name="Outer").cylinder(14.0, 10.0)


### PR DESCRIPTION
## Reproduction
Before this fix, I created a `10 x 5 x 3` box with each backend and inspected `result.shape.bbox`:

```python
from opencad.kernel.core.backend_factory import create_backend
from opencad.kernel.operations.schemas import CreateBoxInput

payload = CreateBoxInput(length=10, width=5, height=3)
for backend in (create_backend("analytic"), create_backend("occt", require_native=True)):
    result = backend.create_box(payload)
    print(result.shape.bbox)
```

The analytic backend returned `(0, 0, 0) -> (10, 5, 3)`. OCCT returned approximately the same corner-based bounds, with its normal `1e-7` Bnd_Box epsilon. The expected centered contract is `(-5, -2.5, -1.5) -> (5, 2.5, 1.5)`.

## Fix
- use half-dimensions for analytic `box_bbox`
- call CadQuery `box(..., centered=True)` in the OCCT backend
- document the centered-box contract in the API reference and fluent `Part` API
- update agent guidance so generated boolean geometry uses the corrected coordinates
- add analytic, OCCT, fluent, and regression coverage

Fixes #94

## Verification
- analytic and OCCT centered-box bounds passed
- positioned boolean smoke test passed
- agent coordinate guidance check passed
- sandbox OpenCAD STEP export produced a valid artifact and feature tree
- `python -m compileall` passed
- Full pytest suite was not run because `pytest` and `uv` are unavailable in the environment
